### PR TITLE
Refactor the tests into their own directory.

### DIFF
--- a/src/fa/__init__.py
+++ b/src/fa/__init__.py
@@ -44,3 +44,4 @@ import updater
 import upnp
 import faction
 import binary
+import featured

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+__author__ = 'Sheeo'
+
+import sys,os
+
+# Allows you to run tests from either tests or root directory
+if os.path.isdir("src"):
+    sys.path.insert(0, os.path.abspath("src"))
+elif os.path.isdir("../src"):
+    sys.path.insert(0, os.path.abspath("../src"))

--- a/tests/fa/__init__.py
+++ b/tests/fa/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Sheeo'

--- a/tests/fa/test_binary.py
+++ b/tests/fa/test_binary.py
@@ -5,8 +5,8 @@ import bsdiff4
 import pytest
 import os
 import pygit2
-import binary
-import sys
+from fa import binary
+
 
 __author__ = 'Thygrrr'
 

--- a/tests/fa/test_featured.py
+++ b/tests/fa/test_featured.py
@@ -1,5 +1,5 @@
 __author__ = 'Thygrrr'
 
 
-import featured
+from fa import featured
 

--- a/tests/fa/test_maps.py
+++ b/tests/fa/test_maps.py
@@ -1,7 +1,7 @@
 __author__ = 'Thygrrr'
 
 import pytest
-import maps
+from fa import maps
 from PyQt4 import QtGui, QtNetwork, QtCore
 
 TESTMAP_NAME = "faf_test_map"

--- a/tests/fa/test_mods.py
+++ b/tests/fa/test_mods.py
@@ -1,6 +1,6 @@
 __author__ = 'Thygrrr'
 
-import mods
+from fa import mods
 import os
 
 def test_fix_init_luas_changes_affected_files(tmpdir):

--- a/tests/fa/test_updater.py
+++ b/tests/fa/test_updater.py
@@ -1,6 +1,6 @@
 __author__ = 'Thygrrr'
 
-import updater
+from fa import updater
 from PyQt4 import QtGui, QtCore
 import pytest
 

--- a/tests/git/__init__.py
+++ b/tests/git/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Sheeo'

--- a/tests/git/test_repository.py
+++ b/tests/git/test_repository.py
@@ -2,7 +2,7 @@ import pytest
 import py
 import os
 import pygit2
-from . import Repository
+from git import Repository
 
 __author__ = 'Thygrrr'
 


### PR DESCRIPTION
Run these with a WD of either tests/ or / and it'll work, since
tests/**init**.py sets up the search path accordingly.

This is a cherry-pick for merging with feature/new-patcher in a PR.

Conflicts:
    tests/fa/test_check.py
    tests/git/test_repository.py
    tests/git/test_version.py
