### PR TITLE
Fix/hidepasswordgames

### DIFF
--- a/res/client/client.css
+++ b/res/client/client.css
@@ -427,6 +427,11 @@ QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManag
 	color:#AAAAAA;
 }
 
+QCheckBox#hideGameWithPw
+{
+	color:#AAAAAA;
+}
+
 QGroupBox
 {
 	color:orange;

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -508,6 +508,13 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="hideGameWithPw">
+        <property name="text">
+         <string>Hide Games with Password</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -1224,7 +1231,6 @@ p, li { white-space: pre-wrap; }
      <zorder>labelTeamManagementHint2</zorder>
      <zorder>teamFaction</zorder>
      <zorder>teamSearch</zorder>
-     <zorder>layoutWidget</zorder>
      <zorder>TeamMapSelectButton</zorder>
      <zorder>verticalSpacer_2</zorder>
      <zorder>leaveTeamButton</zorder>


### PR DESCRIPTION
Sheeo: needs to go after new-patcher and fix-travisbuild

Add a little checkbox, that hide games with password

before:
![image](https://cloud.githubusercontent.com/assets/1217999/4801569/7ada4942-5e35-11e4-9c96-81afa3191c77.png)

after:
![image](https://cloud.githubusercontent.com/assets/1217999/4801573/83e31fd2-5e35-11e4-972d-aa02050e35b4.png)

TODO:
- filter coop games if you hide pw games and then active them
  (Tester TLO was not able to host coop games)
