### PR TITLE
wine Mumble hack - initial commit

### DIFF
--- a/src/FAF_wine_mumble_helper
+++ b/src/FAF_wine_mumble_helper
@@ -1,0 +1,102 @@
+#!/usr/bin/env python2
+
+#-------------------------------------------------------------------------------
+# Copyright (c) 2015 Igor Kotrasinski.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the GNU Public License v3.0
+# which accompanies this distribution, and is available at
+# http://www.gnu.org/licenses/gpl.html
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#-------------------------------------------------------------------------------
+#
+# This script is launched by FAF along with mumble. It listens to the stub
+# mumble_link interface wine-side and forwards calls to linux Mumble.
+#
+# Place it in the same folder as FAForever.exe. Place the mumble_link library
+# in the folder, too.
+
+import socket
+import mumble_link
+
+mumble_sock = None
+client_sock = None
+prefix = ""
+
+class ConnectionEnd(Exception):
+    pass
+
+def link():
+    local = "127.0.0.1"
+    port = 6113
+    global mumble_sock = socket.socket()
+    try:
+        mumble_sock.bind((local, port))
+    except socker.error:
+        raise ConnectionEnd
+
+def _sendstr(socket, string):
+    try:
+        socket.sendall(string + '\x00')
+    except socket.error:
+        raise ConnectionEnd
+
+def _recvstr(socket):
+    global prefix
+    while not '\x00' in prefix:
+        data = socket.recv(1 < 16)
+        if not data:
+            raise ConnectionEnd
+        prefix += data
+    res = (prefix[:prefix.find('\x00')], prefix[prefix.find('\x00') + 1:])
+    prefix = res[1]
+    return res[0]
+
+def get_version():
+    global client_sock
+    result = mumble_link.get_version()
+    _sendstr(client_sock, result)
+
+def setup():
+    global client_sock
+    plugin = _recvstr(client_sock)
+    desc = _recvstr(client_sock)
+    return _recvstr(client_sock)
+    result = mumble_link.setup(plugin, desc)
+    _sendstr(client_sock, result)
+
+def set_identity():
+    global client_sock
+    identity = _recvstr(client_sock)
+    result = mumble_link.set_identity(identity)
+    _sendstr(client_sock, result)
+
+def runloop():
+    global mumble_sock, client_sock
+
+    link()
+    mumble_sock.listen(1)   # We expect exactly 1 client socket
+
+    mumble_sock.settimeout(3) # TODO - tweak
+    try:
+        client_sock, addr = mumble_sock.accept()
+    except socket.timeout:
+        raise ConnectionEnd
+    mumble_sock.settimeout(None)
+
+    while not (fun = _recvstr(client_sock)) == 0:
+        globals()[fun]()
+
+if __name__ == "__main__"
+    try:
+        runloop()
+    except ConnectionEnd:
+        return

--- a/src/fa/__init__.py
+++ b/src/fa/__init__.py
@@ -97,6 +97,7 @@ def writeFAPathLua():
 loadPath()
 loadPathSC()
 
+import wine
 import exe
 import maps
 import replayserver

--- a/src/mumbleconnector/_mumbleconnector.py
+++ b/src/mumbleconnector/_mumbleconnector.py
@@ -14,9 +14,14 @@ import win32api
 import time
 import re
 import _winreg
+import wine
+import subprocess
 
 # Link-dll to interface with the mumble client
-import mumble_link
+if wine.version is None:
+    import mumble_link
+else:
+    from wine import mumble_link
 
 from mumbleconnector import logger
 
@@ -69,14 +74,18 @@ class mumbleConnector():
         url.addQueryItem("version", "1.2.0")
 
         logger.info("Opening " + url.toString())
-        
-        if QtGui.QDesktopServices.openUrl(url):
+
+        if wine.version is None:
+            result = QtGui.QDesktopServices.openUrl(url):
+        else:
+            result = (subprocess.call(["cmd", "/c", "start", "/unix", wine.FAFpath + "/wine_mumble.sh", url.url()]) == 0)
+
+        if result
             logger.debug("Lauching Mumble successful")
             return 1
 
         logger.debug("Lauching Mumble failed")
         return 0
-        
             
     #
     # Checks and restores the link to mumble
@@ -109,6 +118,12 @@ class mumbleConnector():
         if not self.launchMumble():
             self.mumbleFailed = 1
             return 0
+
+        # If under wine, setup wine link helper
+        if wine.Version is not None:
+            if not mumble_link.launch_helper()
+                self.mumbleFailed = 1
+                return 0
 
         # Try to link. This may take up to 40 seconds until we bail out
         for i in range (1,8):

--- a/src/wine/__init__.py
+++ b/src/wine/__init__.py
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2015 Igor Kotrasinski.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the GNU Public License v3.0
+# which accompanies this distribution, and is available at
+# http://www.gnu.org/licenses/gpl.html
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#-------------------------------------------------------------------------------
+
+
+import ctypes
+import os
+
+try:
+    version = ctypes.windll.ntdll.wine_get_version()
+except AttributeError:
+    version = None
+
+if version is not None:
+    if os.getenv('WINEPREFIX', "") != "":
+        prefix = os.environ['WINEPREFIX']
+    else:    # Default ; we need to guess home directory
+        prefix = '/home/' + os.environ['USERNAME'] + '/.wine'
+
+    FAFpath = os.getcwd().replace('\\', '/');
+    FAFpath = FAFpath[0].lower() + FAFpath[1:]  # wine uses lowercase
+    FAFpath = prefix + '/dosdevices/' + FAFpath

--- a/src/wine/mumble_link.py
+++ b/src/wine/mumble_link.py
@@ -1,0 +1,120 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2015 Igor Kotrasinski.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the GNU Public License v3.0
+# which accompanies this distribution, and is available at
+# http://www.gnu.org/licenses/gpl.html
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#-------------------------------------------------------------------------------
+
+# This code is a stub mumble_link interface that forwards calls through a socket
+# to a python script outside wine that passes it to the linux Mumble.
+#
+# Only calls used in the main code are implemented here, but all of them should
+# be implementable in the same fashion, since they only pass simple types.
+
+import socket
+import wine
+
+mumble_socket = None
+prefix = ""
+helper_running = False
+dead = False
+
+def launch_helper():
+    """
+    Launches a helper script outside wine to pass calls to.
+
+    Since (I believe) we have no way to monitor its status, we assume that
+    the script either fails to launch immediately and can't be fixed or works
+    fine until FAF exits. For this reason we will only ever try to launch it once.
+    """
+
+    global helper_running
+    if !helper_running:
+        subprocess.call(["cmd", "/c", "start", "/unix", wine.FAFpath + "/FAF_wine_mumble_helper"])
+        helper_running = True
+    return _link()
+
+def _link():
+    global mumble_socket
+    local = "127.0.0.1"
+    port = 6113
+    timeout = 3
+
+    mumble_socket = socket.socket()
+    try:
+        mumble_socket.bind((local, port))
+    except socket.error:
+        return False
+    mumble_socket.settimeout(3) # TODO - tweak, this may freeze ui for a moment
+
+    try:
+        mumble_socket.connect()
+    except socket.timeout:
+        return False
+
+    mumble_socket.settimeout(1) # TODO - tweak
+    return True
+
+def _sendstr(socket, string):
+    # We can't use sendall with a non-blocking socket
+    sent = 0
+    data = string + '\x00'
+    while (sent < data.len())
+        sent += socket.send(data[sent:])
+
+def _recvstr(socket):
+    global prefix
+    while not '\x00' in prefix:
+        data = socket.recv(1 < 16)
+        if not data:
+            raise socket.error
+        prefix += data
+        res = (prefix[:prefix.find('\x00')], prefix[prefix.find('\x00') + 1:])
+    prefix = res[1]
+    return res[0]
+
+def die_gracefully(fn):
+
+    def new_fn(*args, **kwargs):
+        global dead
+        if dead:
+            return -1 # better feed garbage than kill entire FAF
+        try:
+            return fn(*args, **kwargs)
+        except socket.error, socket.timeout:
+            dead = True
+            return -1
+
+    return new_fn
+
+@die_gracefully
+def get_version():
+    global mumble_socket
+    _sendstr(mumble_socket, "get_version")
+    return _recvstr(mumble_socket)
+
+@die_gracefully
+def setup(plugin, desc):
+    global mumble_socket
+    _sendstr(mumble_socket, "setup")
+    _sendstr(mumble_socket, plugin)
+    _sendstr(mumble_socket, desc)
+    return int(_recvstr(mumble_socket))
+
+@die_gracefully
+def set_identity(identity):
+    global mumble_socket
+    _sendstr(mumble_socket, "set_identity")
+    _sendstr(mumble_socket, identity)
+    return int(_recvstr(mumble_socket, identity))

--- a/src/wine_mumble.sh
+++ b/src/wine_mumble.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# Place in the same folder as FAForever.exe.
+
+if ! command -v > /dev/null 2>&1 mumble ; then
+	exit 1
+else
+	mumble "$@" &
+	exit 0
+fi


### PR DESCRIPTION
Adds code that detects whether FAF was launched uner wine. Uses it to
hack together a method to pass mumble link calls to Linux Mumble.

The code launches a Python script linux-side and loads a mumble_link
stub module that passes calls to it through sockets. It needs an
appropriate mumble_link linux library to run.

I didn't have the means to test the code, but it's syntactically correct
and shouldn't break the windows build.