### PR TITLE
Refactor/server packets

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -4,7 +4,7 @@ from client.updater import fetchClientUpdate
 from config import Settings
 import fa
 from fa.factions import Factions
-from client.server_packets import ServerPackets
+from client.command_dispatcher import CommandDispatcher
 
 '''
 Created on Dec 1, 2011
@@ -121,7 +121,7 @@ class ClientWindow(FormClass, BaseClass):
     def __init__(self, *args, **kwargs):
         BaseClass.__init__(self, *args, **kwargs)
         # Signals for Server Communication
-        self.net = ServerPackets()
+        self.net = CommandDispatcher()
 
         logger.debug("Client instantiating")
 
@@ -1370,18 +1370,9 @@ class ClientWindow(FormClass, BaseClass):
         self.writeToServer(data)
 
     def dispatch(self, message):
-        '''
-        A fairly pythonic way to process received strings as JSON messages.
-        '''     
-
         if "command" in message:
-            # try to find signal to fire
-            signal = self.net.translate(message['command'])
-            if signal:
-                signal.emit(message)
-            else:
-                # otherwise handle old way
-                logger.error("No signal found for (%s)" % (message['command']))
+            if not self.net.dispatch(message['command'], message):
+                logger.debug("No signal found for (%s)" % (message['command']))
 
                 cmd = "handle_" + message['command']
                 if hasattr(self, cmd):

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -4,6 +4,7 @@ from client.updater import fetchClientUpdate
 from config import Settings
 import fa
 from fa.factions import Factions
+from client.server_packets import ServerPackets
 
 '''
 Created on Dec 1, 2011
@@ -95,18 +96,12 @@ class ClientWindow(FormClass, BaseClass):
 
     #These signals propagate important client state changes to other modules
     statsInfo = QtCore.pyqtSignal(dict)
-    tutorialsInfo = QtCore.pyqtSignal(dict)
-    modInfo = QtCore.pyqtSignal(dict)
-    gameInfo = QtCore.pyqtSignal(dict)
-    modVaultInfo = QtCore.pyqtSignal(dict)
-    coopInfo = QtCore.pyqtSignal(dict)
     avatarList = QtCore.pyqtSignal(list)
     playerAvatarList = QtCore.pyqtSignal(dict)
     usersUpdated = QtCore.pyqtSignal(list)
     localBroadcast = QtCore.pyqtSignal(str, str)
     autoJoin = QtCore.pyqtSignal(list)
     channelsUpdated = QtCore.pyqtSignal(list)
-    replayVault = QtCore.pyqtSignal(dict)
     coopLeaderBoard = QtCore.pyqtSignal(dict)
 
     #These signals are emitted whenever a certain tab is activated
@@ -125,6 +120,8 @@ class ClientWindow(FormClass, BaseClass):
 
     def __init__(self, *args, **kwargs):
         BaseClass.__init__(self, *args, **kwargs)
+        # Signals for Server Communication
+        self.net = ServerPackets()
 
         logger.debug("Client instantiating")
 
@@ -165,7 +162,7 @@ class ClientWindow(FormClass, BaseClass):
         fa.instance.started.connect(self.startedFA)
         fa.instance.finished.connect(self.finishedFA)
         fa.instance.error.connect(self.errorFA)
-        self.gameInfo.connect(fa.instance.processGameInfo)
+        self.net.gameInfo.connect(fa.instance.processGameInfo)
 
         #Local Replay Server (and relay)
         self.replayServer = fa.replayserver.ReplayServer(self)
@@ -1378,15 +1375,23 @@ class ClientWindow(FormClass, BaseClass):
         '''     
 
         if "command" in message:
-            cmd = "handle_" + message['command']
-            if hasattr(self, cmd):
-                getattr(self, cmd)(message)
+            # try to find signal to fire
+            signal = self.net.translate(message['command'])
+            if signal:
+                signal.emit(message)
             else:
-                logger.error("Unknown JSON command: %s" % message['command'])
-                raise ValueError
+                # otherwise handle old way
+                logger.error("No signal found for (%s)" % (message['command']))
+
+                cmd = "handle_" + message['command']
+                if hasattr(self, cmd):
+                    getattr(self, cmd)(message)
+                else:
+                    logger.error("Unknown JSON command: %s" % message['command'])
+                    raise ValueError
         else:
             logger.debug("No command in message.")
-
+    # This signal is indirect called over Secondary Server
     def handle_stats(self, message):
         self.statsInfo.emit(message)
 
@@ -1500,29 +1505,12 @@ class ClientWindow(FormClass, BaseClass):
 
         fa.run(game_info, self.relayServer.serverPort(), arguments)
 
-    def handle_coop_info(self, message):
-        self.coopInfo.emit(message)
-
-    def handle_tutorials_info(self, message):
-        self.tutorialsInfo.emit(message)
-
-    def handle_mod_info(self, message):
-        self.modInfo.emit(message)
-
-    def handle_game_info(self, message):
-        self.gameInfo.emit(message)
-
     def handle_modvault_list_info(self, message):
         modList = message["modList"]
         for mod in modList:
             self.handle_modvault_info(mod)
 
-    def handle_modvault_info(self, message):
-        self.modVaultInfo.emit(message)
-
-    def handle_replay_vault(self, message):
-        self.replayVault.emit(message)
-
+    # This signal is indirect called over Secondary Server
     def handle_coop_leaderboard(self, message):
         self.coopLeaderBoard.emit(message)
 

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -95,9 +95,7 @@ class ClientWindow(FormClass, BaseClass):
 
     #These signals propagate important client state changes to other modules
     statsInfo = QtCore.pyqtSignal(dict)
-    tourneyTypesInfo = QtCore.pyqtSignal(dict)
     tutorialsInfo = QtCore.pyqtSignal(dict)
-    tourneyInfo = QtCore.pyqtSignal(dict)
     modInfo = QtCore.pyqtSignal(dict)
     gameInfo = QtCore.pyqtSignal(dict)
     modVaultInfo = QtCore.pyqtSignal(dict)
@@ -1504,12 +1502,6 @@ class ClientWindow(FormClass, BaseClass):
 
     def handle_coop_info(self, message):
         self.coopInfo.emit(message)
-
-    def handle_tournament_types_info(self, message):
-        self.tourneyTypesInfo.emit(message)
-
-    def handle_tournament_info(self, message):
-        self.tourneyInfo.emit(message)
 
     def handle_tutorials_info(self, message):
         self.tutorialsInfo.emit(message)

--- a/src/client/command_dispatcher.py
+++ b/src/client/command_dispatcher.py
@@ -1,8 +1,8 @@
 from PyQt4 import QtCore
 
-class ServerPackets(QtCore.QObject):
 
-    # signals for incoming network packages
+class CommandDispatcher(QtCore.QObject):
+    # Signals for incoming network packages
     tutorialsInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=tutorials_info
     modInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=mod_info
     gameInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=game_info
@@ -10,14 +10,16 @@ class ServerPackets(QtCore.QObject):
     coopInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=coop_info
     replayVault = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=replay_vault
 
-    translation_table = {'tutorials_info' : 'tutorialsInfo',
-                         'mod_info' : 'modInfo',
-                         'game_info' : 'gameInfo',
-                         'modvault_info' : 'modVaultInfo',
-                         'coop_info' : 'coopInfo',
-                         'replay_vault' : 'replayVault'}
+    _signals = {
+        'tutorials_info': 'tutorialsInfo',
+        'mod_info': 'modInfo',
+        'game_info': 'gameInfo',
+        'modvault_info': 'modVaultInfo',
+        'coop_info': 'coopInfo',
+        'replay_vault': 'replayVault'
+    }
 
-    def translate(self, command):
-        if command in self.translation_table:
-            return getattr(self, self.translation_table[command])
-        return None
+    def dispatch(self, command, args):
+        if command in self._signals:
+            getattr(self, self._signals[command]).emit(args)
+            return True

--- a/src/client/server_packets.py
+++ b/src/client/server_packets.py
@@ -1,0 +1,23 @@
+from PyQt4 import QtCore
+
+class ServerPackets(QtCore.QObject):
+
+    # signals for incoming network packages
+    tutorialsInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=tutorials_info
+    modInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=mod_info
+    gameInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=game_info
+    modVaultInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=modvault_info
+    coopInfo = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=coop_info
+    replayVault = QtCore.pyqtSignal(dict)  # https://github.com/FAForever/server/search?q=replay_vault
+
+    translation_table = {'tutorials_info' : 'tutorialsInfo',
+                         'mod_info' : 'modInfo',
+                         'game_info' : 'gameInfo',
+                         'modvault_info' : 'modVaultInfo',
+                         'coop_info' : 'coopInfo',
+                         'replay_vault' : 'replayVault'}
+
+    def translate(self, command):
+        if command in self.translation_table:
+            return getattr(self, self.translation_table[command])
+        return None

--- a/src/coop/_coopwidget.py
+++ b/src/coop/_coopwidget.py
@@ -46,8 +46,8 @@ class CoopWidget(FormClass, BaseClass):
         self.options = []
         
         self.client.showCoop.connect(self.coopChanged)
-        self.client.coopInfo.connect(self.processCoopInfo)
-        self.client.gameInfo.connect(self.processGameInfo)
+        self.client.net.coopInfo.connect(self.processCoopInfo)
+        self.client.net.gameInfo.connect(self.processGameInfo)
         self.coopList.header().setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
         self.coopList.setItemDelegate(CoopMapItemDelegate(self))
 

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -49,8 +49,8 @@ class GamesWidget(FormClass, BaseClass):
         self.ispassworded = False
         self.canChooseMap = True
 
-        self.client.modInfo.connect(self.processModInfo)
-        self.client.gameInfo.connect(self.processGameInfo)
+        self.client.net.modInfo.connect(self.processModInfo)
+        self.client.net.gameInfo.connect(self.processGameInfo)
 
         self.client.gameEnter.connect(self.stopSearchRanked)
         self.client.viewingReplay.connect(self.stopSearchRanked)

--- a/src/modvault/__init__.py
+++ b/src/modvault/__init__.py
@@ -93,7 +93,7 @@ class ModVault(FormClass, BaseClass):
         
         
         self.client.showMods.connect(self.tabOpened)
-        self.client.modVaultInfo.connect(self.modInfo)
+        self.client.net.modVaultInfo.connect(self.modInfo)
 
         self.sortType = "rating"
         self.showType = "all"

--- a/src/mumbleconnector/_mumbleconnector.py
+++ b/src/mumbleconnector/_mumbleconnector.py
@@ -38,7 +38,7 @@ class mumbleConnector():
         self.uid = 0
 
         # Add signal handlers
-        self.client.gameInfo.connect(self.processGameInfo)
+        self.client.net.gameInfo.connect(self.processGameInfo)
         self.client.viewingReplay.connect(self.processViewingReplay)
 
         # Update registry settings for Mumble

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -39,8 +39,8 @@ class ReplaysWidget(BaseClass, FormClass):
         self.client = client
         client.replaysTab.layout().addWidget(self)
         
-        client.gameInfo.connect(self.processGameInfo)
-        client.replayVault.connect(self.replayVault)    
+        client.net.gameInfo.connect(self.processGameInfo)
+        client.net.replayVault.connect(self.replayVault)
         
         self.onlineReplays = {}
         self.onlineTree.setItemDelegate(ReplayItemDelegate(self))

--- a/src/tutorials/_tutorialswidget.py
+++ b/src/tutorials/_tutorialswidget.py
@@ -24,7 +24,7 @@ class tutorialsWidget(FormClass, BaseClass):
         self.sections = {}
         self.tutorials = {}
 
-        self.client.tutorialsInfo.connect(self.processTutorialInfo)
+        self.client.net.tutorialsInfo.connect(self.processTutorialInfo)
         
         logger.info("Tutorials instantiated.")
         


### PR DESCRIPTION
Outsource some incoming server packets calls ...
First step to split network layer from ui code ...

Discoveries:
* We have a seperate tournament server
* We have a seperate stats server that use the `handle_*` methods of the client