### PR TITLE
Display Username instead of UserId in the hosting preview

### DIFF
--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -288,6 +288,12 @@
      <property name="title">
       <string>Chat...</string>
      </property>
+	  <widget class="QMenu" name="menuAutojoin">
+	   <property name="title">
+        <string>Set Autojoin Channels</string>
+       </property>
+	  </widget>
+	 <addaction name="menuAutojoin"/>
      <addaction name="actionColoredNicknames"/>
      <addaction name="actionSetJoinsParts"/>
      <addaction name="actionSetOpenGames"/>

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -30,7 +30,7 @@ class HostgameWidget(FormClass, BaseClass):
         
         self.message = {
             "title": self.parent.gamename,
-            "host": self.parent.client.id,
+            "host": self.parent.client.login,
             "teams": {1:[self.parent.client.id]},
             "featured_mod": "faf",
             "mapname": self.parent.gamemap,


### PR DESCRIPTION
Minor Bugfix,
previosly the UserID was shown instead of the name in the preview/setup window for hosting