### PR TITLE
Display Username instead of UserID in the Hostingpreview

### DIFF
--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -30,7 +30,7 @@ class HostgameWidget(FormClass, BaseClass):
         
         self.message = {
             "title": self.parent.gamename,
-            "host": self.parent.client.id,
+            "host": self.parent.client.login,
             "teams": {1:[self.parent.client.id]},
             "featured_mod": "faf",
             "mapname": self.parent.gamemap,


### PR DESCRIPTION
In the Window where you setup a game before hosting, the ID ofa  user would be displayed instead of the username

PS: 2nd try for this pull request, maybe this time git is on my side :p 