### PR TITLE
Autojoin custom IRC-channels on startup

### DIFF
--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -288,6 +288,12 @@
      <property name="title">
       <string>Chat...</string>
      </property>
+     <widget class="QMenu" name="menuAutojoinIRC">
+      <property name="title">
+        <string>Set Autojoin Channels</string>
+       </property>
+     </widget>
+     <addaction name="menuAutojoinIRC"/>
      <addaction name="actionColoredNicknames"/>
      <addaction name="actionSetJoinsParts"/>
      <addaction name="actionSetOpenGames"/>


### PR DESCRIPTION
Enables automatic joining of channels on startup. The channels to join can be picked in the options on top ( options->chat->Set Autojoin channels->tick or untick channels) . Only channels you are in or that  were in the settings, but that you left since, are shown there.

PS: This is my first bigger commit, so if i did smth wrong or didnt do it stylisticaly right  let me know
PPS: The loading of the Settings is kind of a workaround right now, but it seems to run as intended like that