### PR TITLE
Dont ping window when participant of a pm chat leaves

### DIFF
--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -234,7 +234,7 @@ class Channel(FormClass, BaseClass):
 
         # Play a ping sound and flash the title under certain circumstances
         mentioned = text.find(self.lobby.client.login) != -1
-        if self.private or mentioned:
+        if mentioned or (self.private and not (formatter is Formatters.FORMATTER_RAW and  text=="quit.")):
             self.pingWindow()
 
         avatar = None


### PR DESCRIPTION
The window used to get pinged when the other person of a pm chat left if the tab was still open.
Now it still pings on pm messages and actions in pm ( including "/me quit."), but not when the other person disconnects.