### PR TITLE
Fix private messages from Foes

### DIFF
--- a/res/client/colors.json
+++ b/res/client/colors.json
@@ -1,1 +1,1 @@
-{"you" : "red", "foe" : "crimson", "friend" : "lightskyblue", "friend_mod" : "#70ADA4", "player" : "silver", "server" : "black", "default" : "grey", "self" : "orange", "url" : "cornflowerblue", "clan" : "limegreen"}
+{"you" : "red", "foe" : "#202025", "friend" : "lightskyblue", "friend_mod" : "#70ADA4", "player" : "silver", "server" : "black", "default" : "grey", "self" : "orange", "url" : "cornflowerblue", "clan" : "limegreen"}

--- a/src/chat/__init__.py
+++ b/src/chat/__init__.py
@@ -10,6 +10,12 @@ IRC_ELEVATION = '%@~%+&'
 
 def user2name(user):
     return (user.split('!')[0]).strip(IRC_ELEVATION)
+def user2id(user):
+    try:
+        return int(user.split('!')[1].split('@')[0])
+    except:
+        return None
+
 
 def parse_irc_source(src):
     """

--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -14,7 +14,7 @@ import fa
 
 import sys
 import chat
-from chat import user2name, parse_irc_source
+from chat import user2name, user2id, parse_irc_source
 from chat.channel import Channel
 from chat.irclib import SimpleIRCClient
 import notifications as ns
@@ -404,8 +404,9 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
 
     def on_privmsg(self, c, e):
         name = user2name(e.source())
+        id = user2id(e.source())
 
-        if self.client.players.isFoe(name):
+        if self.client.players.isFoe(id):
             return
 
         # Create a Query if it's not open yet, and post to it if it exists.
@@ -414,9 +415,10 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
 
     def on_action(self, c, e):
         name = user2name(e.source())
+        id = user2id(e.source())
         target = e.target()
 
-        if self.client.players.isFoe(name):
+        if self.client.players.isFoe(id):
             return
 
         # Create a Query if it's not an action intended for a channel


### PR DESCRIPTION
Previously Foes could send private messages  ( and "private actions").
Also Foes blend in with the backgorund, but their messages can be seen when selecting their text.

foes can however still ping one by typying ones name in a chatroom, this will need a fix at  another time