### PR TITLE
Call isFoe more consistently with id and rename stuff inside isFriend…

### DIFF
--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -187,8 +187,8 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
             return False
 
     def openQuery(self, name, activate=False):
-        # Ignore foes, and ourselves.
-        if self.client.players.isFoe(name) or name == self.client.login:
+        # Ignore ourselves.
+        if name == self.client.login:
             return False
 
         if name not in self.channels:
@@ -354,10 +354,11 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
         self.log_event(e)
 
     def on_pubmsg(self, c, e):
+        name, id, elevation, hostname = parse_irc_source(e.source())
         target = e.target()
 
-        if target in self.channels:
-            self.channels[target].printMsg(user2name(e.source()), "\n".join(e.arguments()))
+        if target in self.channels and not self.client.players.isFoe(id):
+            self.channels[target].printMsg(name, "\n".join(e.arguments()))
 
     def on_privnotice(self, c, e):
         source = user2name(e.source())
@@ -403,9 +404,9 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
             self.connect(self.client.me)
 
     def on_privmsg(self, c, e):
-        name = user2name(e.source())
+        name, id, elevation, hostname = parse_irc_source(e.source())
 
-        if self.client.players.isFoe(name):
+        if self.client.players.isFoe(id):
             return
 
         # Create a Query if it's not open yet, and post to it if it exists.
@@ -413,10 +414,10 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
             self.channels[name].printMsg(name, "\n".join(e.arguments()))
 
     def on_action(self, c, e):
-        name = user2name(e.source())
+        name, id, elevation, hostname = parse_irc_source(e.source())#user2name(e.source())
         target = e.target()
 
-        if self.client.players.isFoe(name):
+        if self.client.players.isFoe(id):
             return
 
         # Create a Query if it's not an action intended for a channel

--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -300,7 +300,7 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
         if channel.lower() in self.crucialChannels and name != self.client.login:
             # TODO: search better solution, that html in nick & channel no rendered
             self.client.notificationSystem.on_event(ns.Notifications.USER_ONLINE,
-                                                    {'user': name, 'channel': channel})
+                                                    {'user': id, 'channel': channel})
         self.channels[channel].resizing()
 
     def on_part(self, c, e):

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -283,8 +283,6 @@ class Channel(FormClass, BaseClass):
 
     @QtCore.pyqtSlot(str, str)
     def printMsg(self, name, text, scroll_forced=False):
-        if self.lobby.client.players.isFoe(name):
-            return
         if name in self.chatters and self.chatters[name].avatar:
             fmt = Formatters.FORMATTER_MESSAGE_AVATAR
         else:

--- a/src/client/players.py
+++ b/src/client/players.py
@@ -23,10 +23,10 @@ class Players:
         self.login = None
         self.coloredNicknames = False
         
-        # names of the client's friends
+        # ids of the client's friends
         self.friends = set()
         
-        # names of the client's foes
+        # ids of the client's foes
         self.foes = set()
         
         # names of the client's clanmates
@@ -39,17 +39,17 @@ class Players:
     colors = json.loads(util.readfile("client/colors.json"))
     randomcolors = json.loads(util.readfile("client/randomcolors.json"))
 
-    def isFriend(self, name):
+    def isFriend(self, id):
         '''
         Convenience function for other modules to inquire about a user's friendliness.
         '''
-        return name in self.friends
+        return id in self.friends
 
-    def isFoe(self, name):
+    def isFoe(self, id):
         '''
         Convenience function for other modules to inquire about a user's foeliness.
         '''
-        return name in self.foes
+        return id in self.foes
 
     def isPlayer(self, name):
         '''

--- a/src/notifications/__init__.py
+++ b/src/notifications/__init__.py
@@ -64,12 +64,12 @@ class Notifications:
         pixmap = None
         text = str(data)
         if eventType == self.USER_ONLINE:
-            username = data['user']
-            if self.settings.getCustomSetting(eventType, 'mode') == 'friends' and not self.client.players.isFriend(username):
+            userid = data['user']
+            if self.settings.getCustomSetting(eventType, 'mode') == 'friends' and not self.client.players.isFriend(userid):
                 self.dialogClosed()
                 return
             pixmap = self.user
-            text = '<html>%s<br><font color="silver" size="-2">joined</font> %s</html>' % (username, data['channel'])
+            text = '<html>%s<br><font color="silver" size="-2">joined</font> %s</html>' % (self.client.players[userid].login, data['channel'])
         elif eventType == self.NEW_GAME:
             if self.settings.getCustomSetting(eventType, 'mode') == 'friends' and ('host' not in data or not self.client.players.isFriend(data['host'])):
                 self.dialogClosed()


### PR DESCRIPTION
… and isFoe methods
This should fix foeing in irc, i.e. preventing pm's and not showing what they write in chat channels.
Some stuff based on the game_info message is still not working, for example sorting games and notifications when hosting