### PR TITLE
Changed to user agent used when accessing the map vault to FAForever

### DIFF
--- a/src/vault/__init__.py
+++ b/src/vault/__init__.py
@@ -17,6 +17,12 @@ import json
 
 logger = logging.getLogger(__name__)
 
+class FAFPage(QtWebKit.QWebPage):
+    def __init__(self):
+        super(QtWebKit.QWebPage, self).__init__()
+
+    def userAgentForUrl(self, url):
+        return "FAForever"
 
 class MapVault(QtCore.QObject):
     def __init__(self, client, *args, **kwargs):
@@ -26,6 +32,9 @@ class MapVault(QtCore.QObject):
         logger.debug("Map Vault tab instantiating")
         
         self.ui = QtWebKit.QWebView()
+
+        self.ui.setPage(FAFPage())
+
         self.ui.page().mainFrame().javaScriptWindowObjectCleared.connect(self.addScript)
         
         self.client.mapsTab.layout().addWidget(self.ui)


### PR DESCRIPTION
This is needed so the server recognizes the client as the lobby.

Its actually not a big problem in the mainline client but it might cause bugs and is needed for runs from source.