### PR TITLE
Removed argument wrapping, added working directory for detached

### DIFF
--- a/src/fa/game_process.py
+++ b/src/fa/game_process.py
@@ -2,6 +2,7 @@ import os
 
 from PyQt4 import QtCore, QtGui
 import config
+import re
 
 import logging
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ class GameProcess(QtCore.QProcess):
 
             logger.info("Running FA with info: " + str(info))
             logger.info("Running FA via command: " + command)
+            logger.info("Running FA via executable: " + executable)
 
             # Launch the game as a stand alone process
             if not instance.running():
@@ -52,7 +54,9 @@ class GameProcess(QtCore.QProcess):
                 if not detach:
                     self.start(command)
                 else:
-                    self.startDetached(executable, arguments)
+                    # Remove the wrapping " at the start and end of some arguments as QT will double wrap when launching
+                    arguments = [re.sub('(^"|"$)', '', element) for element in arguments]
+                    self.startDetached(executable, arguments, os.path.dirname(executable))
                 return True
             else:
                 QtGui.QMessageBox.warning(None, "ForgedAlliance.exe", "Another instance of FA is already running.")


### PR DESCRIPTION
QTProcess.startDetached wraps command line arguments that have special characters in them in "", even if they already have such quotes. FA does not like that and dies.

Also set up the working directory to the correct one.