### PR TITLE
Set working directory always to the correct path

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,6 +30,18 @@ import config
 import platform
 import util
 
+# Are we running from a frozen interpreter?
+if getattr(sys, 'frozen', False):
+    os.chdir(os.path.dirname(sys.executable))
+else:
+    # We are most likely running from source
+    srcDir = os.path.dirname(os.path.relpath(__file__))
+    devRoot = os.path.abspath(os.path.join(srcDir, os.pardir))
+    os.chdir(devRoot)
+    # We need to set the working directory correctly.
+
+util.COMMON_DIR = os.path.join(os.getcwd(), "res")
+
 # Set up crash reporting
 excepthook_original = sys.excepthook
 


### PR DESCRIPTION
The working directory is set either to the root of the source of running from source or the directory containing the frozen interpreter (in our case usually FAForever.exe)