### PR TITLE
Sort the userlist with focus on usefulness

### DIFF
--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -291,6 +291,7 @@
       <string>Chat...</string>
      </property>
      <addaction name="actionColoredNicknames"/>
+     <addaction name="actionFriendsOnTop"/>
      <addaction name="actionSetJoinsParts"/>
      <addaction name="actionSetOpenGames"/>
      <addaction name="actionSetLiveReplays"/>
@@ -538,6 +539,14 @@
    </property>
    <property name="text">
     <string>Colored nicknames</string>
+   </property>
+  </action>
+  <action name="actionFriendsOnTop">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Friends on top</string>
    </property>
   </action>
   <action name="actionWiki">

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -97,12 +97,12 @@ class Chatter(QtGui.QTableWidgetItem):
         firstStatus = self.getUserRank(self)
         secondStatus = self.getUserRank(other)
 
+        if self.name == self.lobby.client.login: return True
+
         # if not same rank sort
         if firstStatus != secondStatus:
             return firstStatus < secondStatus
 
-        # List self below all friends and above every other player
-        if self.name == self.lobby.client.login: return True
         if other.name == self.lobby.client.login: return False
 
         # Default: Alphabetical
@@ -110,16 +110,17 @@ class Chatter(QtGui.QTableWidgetItem):
 
     def getUserRank(self, other_chatter):
         # TODO: Add subdivision for admin?
+
         if other_chatter.elevation:
             return self.RANK_ELEVATION
         if self.lobby.client.players.isFriend(other_chatter.id):
-            return self.RANK_FRIEND
+            return self.RANK_FRIEND - (2 if self.lobby.client.friendsontop else 0)
         if self.lobby.client.players.isFoe(other_chatter.id):
             return self.RANK_FOE
         if self.lobby.client.players.isPlayer(other_chatter.id):
             return self.RANK_USER
-        return self.RANK_NONPLAYER
 
+        return self.RANK_NONPLAYER
 
     def updateAvatar(self):
         if self.avatar:        

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -679,6 +679,7 @@ class ClientWindow(FormClass, BaseClass):
         self.actionSaveGamelogs.toggled.connect(self.on_actionSavegamelogs_toggled)
         self.actionSaveGamelogs.setChecked(self.gamelogs)
         self.actionColoredNicknames.triggered.connect(self.updateOptions)
+        self.actionFriendsOnTop.triggered.connect(self.updateOptions)
 
         # Init themes as actions.
         themes = util.listThemes()
@@ -706,6 +707,7 @@ class ClientWindow(FormClass, BaseClass):
 
         self.gamelogs = self.actionSaveGamelogs.isChecked()
         self.players.coloredNicknames = self.actionColoredNicknames.isChecked()
+        self.friendsontop = self.actionFriendsOnTop.isChecked()
 
         self.saveChat()
 
@@ -776,6 +778,7 @@ class ClientWindow(FormClass, BaseClass):
         util.settings.setValue("opengames", self.opengames)
         util.settings.setValue("joinsparts", self.joinsparts)
         util.settings.setValue("coloredNicknames", self.players.coloredNicknames)
+        util.settings.setValue("friendsontop", self.friendsontop)
         util.settings.endGroup()
 
     def loadSettings(self):
@@ -798,9 +801,11 @@ class ClientWindow(FormClass, BaseClass):
             self.joinsparts = (util.settings.value("joinsparts", "false") == "true")
             self.livereplays = (util.settings.value("livereplays", "true") == "true")
             self.players.coloredNicknames = (util.settings.value("coloredNicknames", "false") == "true")
+            self.friendsontop = (util.settings.value("friendsontop", "false") == "true")
 
             util.settings.endGroup()
             self.actionColoredNicknames.setChecked(self.players.coloredNicknames)
+            self.actionFriendsOnTop.setChecked(self.friendsontop)
             self.actionSetSoundEffects.setChecked(self.soundeffects)
             self.actionSetLiveReplays.setChecked(self.livereplays)
             self.actionSetOpenGames.setChecked(self.opengames)


### PR DESCRIPTION
99% of the time when taking a glance at the userlist you want to see if a
certain friend is online / playing / search in vault etc. The white noise is just a distraction.

If you for some reason have to communicate with a moderator they are easy
to find by scrolling down.  New users will see the moderators due to not having any friends anyway.

This will also tone down the "moderators vs aeolus" feeling when you don't have them watching over you all the time.