### PR TITLE
Selecting a subset of factions when searching for a 1 vs 1 match

### DIFF
--- a/res/client/client.css
+++ b/res/client/client.css
@@ -420,7 +420,7 @@ QLabel#labelSortGames,#hideGamesWithPw,#labelJoinGame,#labelHostGame,#labelAutom
     color:white;
 }
 
-QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
+QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelSubsetRankedHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
 {
     color:#AAAAAA;
 }

--- a/res/client/client.css
+++ b/res/client/client.css
@@ -443,11 +443,17 @@ QCheckBox#spoilerCheckbox
 }
 
 /* Used for Ranked Buttons only at the moment*/
+QToolButton#rankedPlay
+{
+	color: silver;
+	border-radius: 5px;
+	border: 1px solid grey;
+}
+
 QToolButton::pressed 
 {
     border: none;
-
-    color:silver;
+    color: black;
     padding:5px;
     background-color:#383838;
     border-radius : 5px;
@@ -468,7 +474,7 @@ QToolButton::checked
     border: none;
     border: 2px solid #353535;
 
-    color:silver;
+    color:black;
     padding:5px;
     background-color:#C0C0C0;
     border-radius : 5px;

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -569,7 +569,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Use subset (1 vs 1)</string>
+    <string>Select subset of factions</string>
    </property>
   </action>
  </widget>

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -247,7 +247,7 @@
      <x>0</x>
      <y>0</y>
      <width>1186</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuOptions">
@@ -266,6 +266,7 @@
      <addaction name="actionSetGamePort"/>
      <addaction name="actionSaveGamelogs"/>
      <addaction name="separator"/>
+     <addaction name="actionUseSubset"/>
     </widget>
     <widget class="QMenu" name="menuTheme">
      <property name="tearOffEnabled">
@@ -563,12 +564,20 @@
     <string>Settings</string>
    </property>
   </action>
+  <action name="actionUseSubset">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Use subset (1 vs 1)</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
    <class>QWebView</class>
    <extends>QWidget</extends>
-   <header>QtWebKitWidgets/QWebView</header>
+   <header>QtWebKit/QWebView</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -569,7 +569,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Select subset of factions</string>
+    <string>Select multiple factions</string>
    </property>
   </action>
  </widget>

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -84,7 +84,7 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QProgressBar" name="searchProgress">
            <property name="font">
             <font>
@@ -110,6 +110,22 @@
             <string>scanning</string>
            </property>
           </widget>
+         </item>
+         <item row="4" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
          </item>
          <item row="0" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -378,24 +394,20 @@
            </item>
           </layout>
          </item>
-         <item row="3" column="0">
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+         <item row="2" column="0">
+          <widget class="QToolButton" name="rankedPlay">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Minimum</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
+           <property name="minimumSize">
             <size>
-             <width>5</width>
-             <height>5</height>
+             <width>0</width>
+             <height>25</height>
             </size>
            </property>
-          </spacer>
-         </item>
-         <item row="1" column="0">
-          <widget class="QPushButton" name="rankedPlay">
            <property name="autoFillBackground">
             <bool>true</bool>
            </property>
@@ -403,6 +415,22 @@
             <string>Play!</string>
            </property>
           </widget>
+         </item>
+         <item row="1" column="0">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -408,6 +408,15 @@
              <height>25</height>
             </size>
            </property>
+           <property name="acceptDrops">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string extracomment="Select some factions and start searching for a 1 vs 1 match"/>
+           </property>
            <property name="autoFillBackground">
             <bool>true</bool>
            </property>

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -472,6 +472,23 @@ p, li { white-space: pre-wrap; }
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="labelSubsetRankedHint">
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a few of your favorite factions and hit play to get matched against a player of your level in a random map !&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="labelHostGame">
         <property name="font">
          <font>

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -84,6 +84,33 @@
          <property name="spacing">
           <number>0</number>
          </property>
+         <item row="2" column="0">
+          <widget class="QProgressBar" name="searchProgress">
+           <property name="font">
+            <font>
+             <pointsize>4</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Scanning for Opponents</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>0</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="format">
+            <string>scanning</string>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="0">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <property name="spacing">
@@ -351,7 +378,7 @@
            </item>
           </layout>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -368,29 +395,12 @@
           </spacer>
          </item>
          <item row="1" column="0">
-          <widget class="QProgressBar" name="searchProgress">
-           <property name="font">
-            <font>
-             <pointsize>4</pointsize>
-            </font>
+          <widget class="QPushButton" name="rankedPlay">
+           <property name="autoFillBackground">
+            <bool>true</bool>
            </property>
-           <property name="toolTip">
-            <string>Scanning for Opponents</string>
-           </property>
-           <property name="minimum">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <number>0</number>
-           </property>
-           <property name="value">
-            <number>0</number>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="format">
-            <string>scanning</string>
+           <property name="text">
+            <string>Play!</string>
            </property>
           </widget>
          </item>

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -634,6 +634,8 @@ class ClientWindow(FormClass, BaseClass):
         self.doneresize.emit()
 
     def initMenus(self):
+        from  games._gameswidget import PLAY_SUBSET_SELECT
+
         self.actionLink_account_to_Steam.triggered.connect(partial(self.open_url, Settings.get("STEAMLINK_URL")))
         self.actionLinkWebsite.triggered.connect(partial(self.open_url, Settings.get("WEBSITE_URL")))
         self.actionLinkWiki.triggered.connect(partial(self.open_url, Settings.get("WIKI_URL")))
@@ -656,8 +658,9 @@ class ClientWindow(FormClass, BaseClass):
 
         self.actionSetGamePath.triggered.connect(self.switchPath)
         self.actionSetGamePort.triggered.connect(self.switchPort)
-        self.actionUseSubset.triggered.connect(self.updateOptions)
-        self.actionUseSubset.setChecked(bool(Settings.get("play/selectSubset")))
+
+        self.actionUseSubset.triggered.connect(self.switchSubset)
+        self.actionUseSubset.setChecked(Settings.get(PLAY_SUBSET_SELECT, type=bool, default=False))
 
         # Toggle-Options
         self.actionSetAutoLogin.triggered.connect(self.updateOptions)
@@ -711,6 +714,10 @@ class ClientWindow(FormClass, BaseClass):
     def switchPort(self):
         import loginwizards
         loginwizards.gameSettingsWizard(self).exec_()
+
+    def switchSubset(self, enabled):
+        Settings.set("play/selectSubset", enabled)
+        self.games.generateSelectSubset()
 
     @QtCore.pyqtSlot()
     def clearSettings(self):

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -634,8 +634,6 @@ class ClientWindow(FormClass, BaseClass):
         self.doneresize.emit()
 
     def initMenus(self):
-        from  games._gameswidget import PLAY_SUBSET_SELECT
-
         self.actionLink_account_to_Steam.triggered.connect(partial(self.open_url, Settings.get("STEAMLINK_URL")))
         self.actionLinkWebsite.triggered.connect(partial(self.open_url, Settings.get("WEBSITE_URL")))
         self.actionLinkWiki.triggered.connect(partial(self.open_url, Settings.get("WIKI_URL")))
@@ -660,7 +658,7 @@ class ClientWindow(FormClass, BaseClass):
         self.actionSetGamePort.triggered.connect(self.switchPort)
 
         self.actionUseSubset.triggered.connect(self.switchSubset)
-        self.actionUseSubset.setChecked(Settings.get(PLAY_SUBSET_SELECT, type=bool, default=False))
+        self.actionUseSubset.setChecked(Settings.get("play/selectSubset", type=bool, default=False))
 
         # Toggle-Options
         self.actionSetAutoLogin.triggered.connect(self.updateOptions)

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -656,6 +656,8 @@ class ClientWindow(FormClass, BaseClass):
 
         self.actionSetGamePath.triggered.connect(self.switchPath)
         self.actionSetGamePort.triggered.connect(self.switchPort)
+        self.actionUseSubset.triggered.connect(self.updateOptions)
+        self.actionUseSubset.setChecked(bool(Settings.get("play/selectSubset")))
 
         # Toggle-Options
         self.actionSetAutoLogin.triggered.connect(self.updateOptions)

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -151,6 +151,7 @@ class GamesWidget(FormClass, BaseClass):
         if(self.use_subset):
             self.rankedPlay.clicked.connect(self.startSubRandomRankedSearch)
             self.rankedPlay.show()
+            self.rankedRandom.hide()
             self.labelRankedHint.setText("Select a few of your favorite factions and hit play to get matched against a player of your level in a random map !")
             for faction, icon in self._ranked_icons.items():
                 if(disconnect):
@@ -160,6 +161,7 @@ class GamesWidget(FormClass, BaseClass):
                 icon.clicked.connect(self.selectSubset)
         else:
             self.rankedPlay.hide()
+            self.rankedRandom.show()
             self.labelRankedHint.setText("Select your favorite faction and get matched against a player of your level in a random map !")
             for faction, icon in self._ranked_icons.items():
                 if(disconnect):

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -12,6 +12,7 @@ from fa.factions import Factions
 import fa
 import modvault
 import notifications as ns
+from config import Settings
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,6 +20,9 @@ logger = logging.getLogger(__name__)
 FormClass, BaseClass = util.loadUiType("games/games.ui")
 
 class GamesWidget(FormClass, BaseClass):
+
+    selectSubset = Settings.persisted_property("play/selectSubset", type=bool, default_value=False)
+
     def __init__(self, client, *args, **kwargs):
         BaseClass.__init__(self, *args, **kwargs)
 
@@ -48,8 +52,14 @@ class GamesWidget(FormClass, BaseClass):
         self.rankedUEF.setIcon(util.icon("games/automatch/uef.png"))
         self.rankedRandom.setIcon(util.icon("games/automatch/random.png"))
 
-        for faction, icon in self._ranked_icons.items():
-            icon.clicked.connect(partial(self.toggle_search, faction=faction))
+        if(Settings.get("play/selectSubset")):
+            self.rankedPlay.show()
+            for faction, icon in self._ranked_icons.items():
+                icon.clicked.connect(partial(self.selectSubset, faction=faction))
+        else:
+            self.rankedPlay.hide()
+            for faction, icon in self._ranked_icons.items():
+                icon.clicked.connect(partial(self.toggle_search, faction=faction))
 
         self.searchProgress.hide()
 
@@ -107,6 +117,9 @@ class GamesWidget(FormClass, BaseClass):
                      if self.games[game].state == 'open'
                      and self.games[game].password_protected]:
             game.setHidden(state == Qt.Checked)
+
+    def selectSubset(self, enabled, faction=None):
+
 
     @QtCore.pyqtSlot()
     def clear_games(self):

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -155,7 +155,8 @@ class GamesWidget(FormClass, BaseClass):
             self.rankedPlay.clicked.connect(self.startSubRandomRankedSearch)
             self.rankedPlay.show()
             self.rankedRandom.hide()
-            self.labelRankedHint.setText("Select a few of your favorite factions and hit play to get matched against a player of your level in a random map !")
+            self.labelRankedHint.hide()
+            self.labelSubsetRankedHint.show()
             for faction, icon in self._ranked_icons.items():
                 if(disconnect):
                     icon.clicked.disconnect()
@@ -165,7 +166,8 @@ class GamesWidget(FormClass, BaseClass):
         else:
             self.rankedPlay.hide()
             self.rankedRandom.show()
-            self.labelRankedHint.setText("Select your favorite faction and get matched against a player of your level in a random map !")
+            self.labelRankedHint.show()
+            self.labelSubsetRankedHint.hide()
             for faction, icon in self._ranked_icons.items():
                 if(disconnect):
                     icon.clicked.disconnect()


### PR DESCRIPTION
Rather straight forward feature. The user has the option to select in the option menu to change the behaviour of the buttons by being able to select multiple factions and then press play. The client will choose a faction for the user and start searching. 

Existing code has been changed by this as startRankedSearch does not check/uncheck the buttons anymore but is moved to toggle_search.
For creating the ui another method has been added that takes care of the setting the correct handlers on the buttons when the option in the option menu has been selected. It's also called from the constructor.
All changes are saved in the settings file of the user (if he uses the subset selection and the factions selected).

Sadly i've been unable to get the tests to run for a while now so it's only been tested by hand.
