### PR TITLE
Exit when port is in use

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -70,7 +70,7 @@ def runFAF():
     faf_client = client.instance
     faf_client.setup()
 
-    faf_client.doConnect()
+    if not faf_client.doConnect(): exit(1)
     faf_client.doLogin()
 
     faf_client.show()


### PR DESCRIPTION
Client now does something when doConnect fails as previously it would continue starting the client even though there was no chance on recovery.

Fixing #309
