### PR TITLE
Pass an ID over when opening a private chat

### DIFF
--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -183,7 +183,7 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
                     self.channels[channel].printAction("IRC", "was disconnected.")
             return False
 
-    def openQuery(self, name, activate=False):
+    def openQuery(self, name, id=-1, activate=False):
         # Ignore ourselves.
         if name == self.client.login:
             return False
@@ -193,8 +193,8 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
             self.addTab(self.channels[name], name)
 
             # Add participants to private channel
-            self.channels[name].addChatter(name)
-            self.channels[name].addChatter(self.client.login)
+            self.channels[name].addChatter(name, id)
+            self.channels[name].addChatter(self.client.login, self.client.me.id)
 
         if activate:
             self.setCurrentWidget(self.channels[name])
@@ -411,7 +411,7 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
             return
 
         # Create a Query if it's not open yet, and post to it if it exists.
-        if self.openQuery(name):
+        if self.openQuery(name, id):
             self.channels[name].printMsg(name, "\n".join(e.arguments()))
 
     def on_action(self, c, e):
@@ -423,7 +423,7 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
 
         # Create a Query if it's not an action intended for a channel
         if target not in self.channels:
-            self.openQuery(name)
+            self.openQuery(name,id)
             self.channels[name].printAction(name, "\n".join(e.arguments()))
         else:
             self.channels[target].printAction(name, "\n".join(e.arguments()))

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -231,7 +231,7 @@ class Chatter(QtGui.QTableWidgetItem):
             return
         # Chatter name clicked
         if item == self:
-            self.lobby.openQuery(self.name, True)  # open and activate query window
+            self.lobby.openQuery(self.name, self.id, activate=True)  # open and activate query window
 
         elif item == self.statusItem:
             if self.name in client.instance.urls:


### PR DESCRIPTION
Due to this chatter get their respective color in private chats instead of the default irc dark grey. However the text can be white/blue/green/etc depending on friend/etc status, dunno if that is the intended state or just plain light gray for everything in private messages.
Depending on Interpretation this fixes #291 , atleast it should make it consistent :P
