### PR TITLE
Show what map people are playing / lobbying in nickname list

### DIFF
--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -10,6 +10,8 @@ from chat import user2name
 from config import Settings
 
 from fa.replay import replay
+from fa import maps
+
 import util
 
 import client
@@ -183,15 +185,25 @@ class Chatter(QtGui.QTableWidgetItem):
         # Status icon handling
         url = client.instance.urls.get(player.login)
         if url:
+            icon_url = None
             if url.scheme() == "fafgame":
-                self.statusItem.setIcon(util.icon("chat/status/lobby.png"))
+                icon_url = "chat/status/lobby.png"
                 self.statusItem.setToolTip("In Game Lobby<br/>"+url.toString())
             elif url.scheme() == "faflive":
-                self.statusItem.setIcon(util.icon("chat/status/playing.png"))
+                icon_url = "chat/status/playing.png"
                 self.statusItem.setToolTip("Playing Game<br/>"+url.toString())
-        else:
-            self.statusItem.setIcon(QtGui.QIcon())
-            self.statusItem.setToolTip("Idle")
+
+            if icon_url:
+                mapname = url.queryItemValue('map')
+                icon = maps.preview(mapname)
+                if not icon:
+                    self.lobby.client.downloader.downloadMap(mapname, self)
+                    icon = util.icon(icon_url)
+
+                self.statusItem.setIcon(icon)
+            else:
+                self.statusItem.setIcon(QtGui.QIcon())
+                self.statusItem.setToolTip("Idle")
 
         #Rating icon choice
         #TODO: These are very basic and primitive


### PR DESCRIPTION
I like miniature Seton's icon spam instead of crossed swords spam.

Should be seen as a work in progress at this point,  need some way to show if a player is in a lobby or in an actual game. Maybe put the current used sword icon next to the map icon? 

Open for suggestions :bulb: 
![faf](https://cloud.githubusercontent.com/assets/254972/14493925/6b0798a6-0188-11e6-9e1e-9556e2e1df0e.png)
