### PR TITLE
Save gamelogs as default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 * Add linux support (thanks @muellni)
 * Add new uid implementation (thanks @muellni)
 * Leaderboard display performance improvement (#438, thanks @grotheFAF)
+* Save game logs as default
 
 0.11.60
 =======

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -142,7 +142,7 @@ class ClientWindow(FormClass, BaseClass):
     login = Settings.persisted_property('user/login', persist_if=lambda self: self.remember)
     password = Settings.persisted_property('user/password', persist_if=lambda self: self.remember)
 
-    gamelogs = Settings.persisted_property('game/logs', type=bool, default_value=False)
+    gamelogs = Settings.persisted_property('game/logs', type=bool, default_value=True)
     useUPnP = Settings.persisted_property('game/upnp', type=bool, default_value=True)
     gamePort = Settings.persisted_property('game/port', type=int, default_value=6112)
 


### PR DESCRIPTION
Any particular reason why saving game logs defaults to off? Saving them as default will save us the trouble of informing people to enable it for debugging purposes.
