### PR TITLE
Only check for uid in game_info of a single game

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1325,16 +1325,17 @@ class ClientWindow(FormClass, BaseClass):
         self.modInfo.emit(message)
 
     def handle_game_info(self, message):
-        if message['uid'] == self.game_session.game_uid:
-            self.game_session.game_map = message['mapname']
-            self.game_session.game_mod = message['featured_mod']
-            self.game_session.game_name = message['title']
-            self.game_session.game_visibility = message['visibility']
-
         if 'games' in message:
             for game in message['games']:
                 self.gameInfo.emit(game)
         else:
+            # sometimes we get the game_info message before a game session was created
+            if self.game_session and message['uid'] == self.game_session.game_uid:
+                self.game_session.game_map = message['mapname']
+                self.game_session.game_mod = message['featured_mod']
+                self.game_session.game_name = message['title']
+                self.game_session.game_visibility = message['visibility']
+
             self.gameInfo.emit(message)
 
     def handle_modvault_list_info(self, message):


### PR DESCRIPTION
Before it used check as well if multiple games were sent in one block, where it couldnt find the 'uid' key
Example Error:

```
2016-06-04 14:55:04,266 ERROR    client._clientwindow           Error dispatching JSON: {"games": [{"uid": 4806680, "featured_mod": "faf", ...
Traceback
 (most recent call last):
  File "src\client\_clientwindow.py", line 988, in readFromServer
    self.dispatch(json.loads(action))
  File "src\client\_clientwindow.py", line 1118, in dispatch
    getattr(self, cmd)(message)
  File "src\client\_clientwindow.py", line 1328, in handle_game_info
    if message['uid'] == self.game_session.game_uid:
KeyError: 'uid'
```
