### PR TITLE
Queue up bind requests if game conn isn't ready

### DIFF
--- a/src/fa/game_session.py
+++ b/src/fa/game_session.py
@@ -149,6 +149,7 @@ class GameSession(QObject):
         if self._bind_queue:
             for f in self._bind_queue:
                 f()
+            self._bind_queue = []
 
     def _on_game_message(self, command, args):
         self._logger.info("Incoming GPGNet: {} {}".format(command, args))


### PR DESCRIPTION
Seems like peer_bound requests sometime gets triggered before the FA process has connected to the client (thus no game_connection active).

Example of user experiencing this error:
http://forums.faforever.com/viewtopic.php?f=3&t=12577

```
2016-06-11 22:45:21,256 INFO     connectivity.relay.Relay       Allocating local relay for turinturambar, 136480
2016-06-11 22:45:21,256 INFO     fa.game_session.GameSession    Bound peer turinturambar/136480 to 65442
2016-06-11 22:45:21,256 ERROR    __main__                       Uncaught exception
Traceback (most recent call last):
  File "src\fa\game_session.py", line 123, in _peer_bound
AttributeError: 'NoneType' object has no attribute 'send'
2016-06-11 22:45:21,365 INFO     requests.packages.urllib3.connectionpool Starting new HTTP connection (1): api.dev.faforever.com
2016-06-11 22:45:25,678 INFO     fa.game_session.GameSession    Game connected through GPGNet
```

@sheeo, is it theoretically possible that a slow FA startup can cause this?

If this is the case then this PR will fix that by queue up peer_bound requests which then is executed when the actual game connection is established (maybe there is a better way to solve this?)
