### PR TITLE
Redesign UI in replay vault

### DIFF
--- a/res/client/client.css
+++ b/res/client/client.css
@@ -219,7 +219,11 @@ QSplitter::handle:hover
      background-color: #606060;
  }
 
-
+QSpinBox#minRating, QLineEdit#mapName, QLineEdit#playerName, QComboBox#modList
+{
+    background-color: #353535;
+    color: orange;
+}
 
 /* Text controls */
 QTextEdit, QPlainTextEdit, QLineEdit, QListWidget, QTableWidget, QTreeWidget, QFrame#rankedFrame, QFrame#teamFaction, QFrame#teamSearch
@@ -332,9 +336,6 @@ QTreeWidget::item:selected, QTreeWidget::item:previously-selected
     border: none;
 }
 
- 
-
-
 /* ScrollWidgets*/
 QScrollArea
 {
@@ -427,8 +428,16 @@ QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManag
 
 QGroupBox
 {
-    color:orange;
-    background-color: grey;
+    margin: 5px;
+    border: 1px solid #353535;
+    border-radius: 5px;
+    background-color: rgb(32, 32, 37);
+    color: silver;
+}
+
+QLabel
+{
+    color: silver;
 }
 
 /* Used for dialogs*/

--- a/res/replays/replays.ui
+++ b/res/replays/replays.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>977</width>
+    <width>1062</width>
     <height>672</height>
    </rect>
   </property>
@@ -168,8 +168,256 @@
     <property name="margin">
      <number>0</number>
     </property>
-    <item row="0" column="0" rowspan="2">
+    <item row="2" column="1">
+     <widget class="QWidget" name="widget" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>200</width>
+        <height>150</height>
+       </size>
+      </property>
+      <property name="sizeIncrement">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="1" column="2">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>275</width>
+           <height>175</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>275</width>
+           <height>175</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Search options</string>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <property name="rowWrapPolicy">
+           <enum>QFormLayout::DontWrapRows</enum>
+          </property>
+          <property name="horizontalSpacing">
+           <number>4</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>4</number>
+          </property>
+          <property name="margin">
+           <number>19</number>
+          </property>
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>Player : </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="playerName"/>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>Map : </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="mapName"/>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="spoilerCheckbox">
+            <property name="text">
+             <string>Spoiler Free</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>Mod : </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="modList">
+              <item>
+               <property name="text">
+                <string>All</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="autoFillBackground">
+               <bool>false</bool>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>Min rating : </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="minRating">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="minimum">
+               <number>-200</number>
+              </property>
+              <property name="maximum">
+               <number>3000</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="4" column="1">
+           <widget class="QPushButton" name="searchButton">
+            <property name="text">
+             <string>Search</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+      <zorder>groupBox</zorder>
+      <zorder>horizontalSpacer</zorder>
+      <zorder>verticalSpacer</zorder>
+      <zorder>verticalSpacer_2</zorder>
+      <zorder>horizontalSpacer_2</zorder>
+     </widget>
+    </item>
+    <item row="1" column="0" rowspan="4">
      <widget class="QTreeWidget" name="onlineTree">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="minimumSize">
        <size>
         <width>550</width>
@@ -180,6 +428,12 @@
        <size>
         <width>550</width>
         <height>16777215</height>
+       </size>
+      </property>
+      <property name="sizeIncrement">
+       <size>
+        <width>50</width>
+        <height>0</height>
        </size>
       </property>
       <property name="sortingEnabled">
@@ -209,140 +463,96 @@
       </column>
      </widget>
     </item>
-    <item row="0" column="2">
-     <spacer name="horizontalSpacer">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeType">
-       <enum>QSizePolicy::MinimumExpanding</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>0</width>
-        <height>0</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item row="1" column="2" colspan="3">
-     <widget class="QTextBrowser" name="replayInfos">
-      <property name="textInteractionFlags">
-       <set>Qt::NoTextInteraction</set>
-      </property>
-      <property name="openExternalLinks">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="QGroupBox" name="groupBox">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="title">
-       <string>Search options</string>
-      </property>
-      <property name="flat">
-       <bool>true</bool>
-      </property>
+    <item row="3" column="1">
+     <widget class="QWidget" name="widget_2" native="true">
       <layout class="QGridLayout" name="gridLayout_3">
-       <property name="horizontalSpacing">
-        <number>6</number>
-       </property>
-       <property name="verticalSpacing">
-        <number>2</number>
-       </property>
-       <item row="0" column="0" colspan="2">
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Player :</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="playerName"/>
-         </item>
-        </layout>
+       <item row="0" column="1">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item row="1" column="0" colspan="2">
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Map :</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="mapName"/>
-         </item>
-        </layout>
+       <item row="2" column="1">
+        <spacer name="verticalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item row="2" column="0" colspan="2">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Mod :</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="modList">
-           <item>
-            <property name="text">
-             <string>All</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="2">
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item row="3" column="0" rowspan="2" colspan="2">
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Min rating :</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="minRating">
-           <property name="minimum">
-            <number>-200</number>
-           </property>
-           <property name="maximum">
-            <number>3000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item row="5" column="0">
-        <widget class="QPushButton" name="searchButton">
-         <property name="text">
-          <string>Search</string>
+       <item row="1" column="1">
+        <widget class="QTextBrowser" name="replayInfos">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>400</width>
+           <height>150</height>
+          </size>
+         </property>
+         <property name="sizeIncrement">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::NoTextInteraction</set>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
       </layout>
-     </widget>
-    </item>
-    <item row="0" column="3">
-     <widget class="QCheckBox" name="spoilerCheckbox">
-      <property name="text">
-       <string>Spoiler Free</string>
-      </property>
-      <property name="checked">
-       <bool>true</bool>
-      </property>
      </widget>
     </item>
    </layout>

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -122,6 +122,7 @@ class ReplaysWidget(BaseClass, FormClass):
                 elif item.spoiled != self.spoilerCheckbox.isChecked():
                     self.replayInfos.clear()
                     self.replayInfos.setHtml(item.replayInfo)
+                    item.resize()
                 else:
                     self.replayInfos.clear()
                     item.generateInfoPlayersHtml()
@@ -291,6 +292,7 @@ class ReplaysWidget(BaseClass, FormClass):
                         # Add additional info
                         item.setText(3, item.info['featured_mod'])
                         item.setTextAlignment(3, QtCore.Qt.AlignCenter)
+                        item.setTextColor(1, QtGui.QColor(client.instance.players.getUserColor(item.info.get('recorder', ""))))
                     else:
                         bucket = buckets.setdefault("incomplete", [])                    
                         item.setIcon(0, util.icon("replays/replay.png"))
@@ -416,7 +418,7 @@ class ReplaysWidget(BaseClass, FormClass):
                     url.setPath(str(info["uid"]) + "/" + name + ".SCFAreplay")
                     url.addQueryItem("map", info["mapname"])
                     url.addQueryItem("mod", info["featured_mod"])
-                    
+
                     playeritem.url = url
                     if client.instance.login == name:
                         mygame = True
@@ -439,6 +441,7 @@ class ReplaysWidget(BaseClass, FormClass):
                         playeritem.setDisabled(True)
 
                     item.addChild(playeritem)
+                    self.liveTree.setFirstItemColumnSpanned(playeritem, True)
         elif info['state'] == "closed":
             if info['uid'] in self.games:
                 self.liveTree.takeTopLevelItem(self.liveTree.indexOfTopLevelItem(self.games[info['uid']]))

--- a/src/replays/replayitem.py
+++ b/src/replays/replayitem.py
@@ -4,6 +4,7 @@
 
 from PyQt4 import QtCore, QtGui
 from fa import maps
+from fa.factions import Factions
 import util
 import os, time
 from games.moditem import mods
@@ -72,9 +73,15 @@ class ReplayItemDelegate(QtGui.QStyledItemDelegate):
 class ReplayItem(QtGui.QTreeWidgetItem):
 
     
-    FORMATTER_REPLAY        = unicode(util.readfile("replays/formatters/replay.qthtml"))
+    FORMATTER_REPLAY                = unicode(util.readfile("replays/formatters/replay.qthtml"))
+    FORMATTER_REPLAY_INFORMATION    = "<h2 align='center'>Replay UID : {uid}</h2></br></br><table border='0' cellpadding='0' cellspacing='5' align='center'><tbody><tr>{teams}</tr></tbody></table>"
+    FORMATTER_REPLAY_TEAM_SPOILED   = "<td><table border=0 width=100% height=100%><table border=0 width=100% height=100%><tr><td align='center' valign='center' width=100%><font size='+2'>{title}</font></td></tr></table>{players}</table></td>"
+    FORMATTER_REPLAY_FFA_SPOILED    = "<td><table border=0 width=100% height=100%><table border=0 width=100% height=100%><tr><td align='center' valign='center' width=100%><font size='+2'>Winner</font></td></tr></table><br></br>{winner}</table></td><table border=0 width=100% height=100%><table border=0 width=100% height=100%><tr><td align='center' valign='center' width=100%><font size='+2'>Other</font></td></tr></table><br></br>{players}</table></td>"
+    FORMATTER_REPLAY_TEAM           = "<td><table border=0 width=100% height=100%>{players}</table></td>"
+    FORMATTER_REPLAY_PLAYER_LABEL   = "<td align='{alignment}' valign='center' width=150>{player_name} ({player_rating})</td>"
+    FORMATTER_REPLAY_PLAYER_ICON    = "<td width='40'><img src='{faction_icon_uri}' width='40' height='20'></td>"
 
-    
+
     def __init__(self, uid, parent, *args, **kwargs):
         QtGui.QTreeWidgetItem.__init__(self, *args, **kwargs)
 
@@ -97,6 +104,7 @@ class ReplayItem(QtGui.QTreeWidgetItem):
         self.replayInfo     = False
         self.spoiled        = False
         self.url            = "{}/faf/vault/replay_vault/replay.php?id={}".format(Settings.get('content/host'), self.uid)
+
         
         self.teams          = {}
         self.access         = None
@@ -105,9 +113,12 @@ class ReplayItem(QtGui.QTreeWidgetItem):
 
         self.options        = []
         self.players        = []
+        self.biggestTeam    = 0
+        self.winner         = None
         
         self.setHidden(True)
-
+        self.extraInfoWidth          = 0 #panel with more information
+        self.extraInfoHeight         = 0 #panel with more information
     
     def update(self, message, client):
         '''
@@ -151,16 +162,23 @@ class ReplayItem(QtGui.QTreeWidgetItem):
         self.viewtext = (self.FORMATTER_REPLAY.format(time=self.startHour, name=self.name, map = self.mapdisplayname, duration = self.duration, mod = self.moddisplayname))
 
     def infoPlayers(self, players):
-        
+        '''
+        processes information from the server about a replay into readable extra information for the user, also calls method to show the information
+        '''
         self.moreInfo = True
+        mvpscore = 0
+        mvp = None
         scores = {}
         
         for player in players :
             team            = int(player["team"])
-            
 
-            if team :
+            if team : #even if it's FFA the players are still in team 1
                 if "score" in player :
+                    if player["score"] > mvpscore:
+                        mvp = player
+                        mvpscore = player["score"]
+
                     if team in scores :
                         scores[team] = scores[team] + player["score"]
                     else :
@@ -171,103 +189,118 @@ class ReplayItem(QtGui.QTreeWidgetItem):
                     self.teams[team].append(player)
 
         self.teamWin = None
-        if len(scores) > 0 :
-            winner = 0
+
+        if len(self.teams) == 1 and 1 in self.teams : #it's FFA
+            self.winner = mvp
+        elif len(scores) > 0:
+            winner = -10
             for team in scores :
                 if scores[team] > winner :
                     self.teamWin = team
+                    winner = scores[team]
 
         self.generateInfoPlayersHtml()
-                
-    def generateInfoPlayersHtml(self):
-        observerlist    = []
-        teamlist        = []
 
+
+
+    def generateInfoPlayersHtml(self):
+        '''
+        Creates the ui and extra information about a replay,
+        Either teamWin or winner must be set if the replay is to be spoiled
+
+        '''
+        observerlist    = []
         teams = ""
+        winnerHTML = "";
+
         self.spoiled = self.parent.spoilerCheckbox.isChecked() == False
 
         i = 0
         for team in self.teams:
             if team != -1 :
-                i = i + 1
-                teamtxt = "<table border=0 width = 100% height = 100%>"
+                i += 1
 
-                teamDisplay    = []
-                if self.teamWin and self.spoiled:
-                    if self.teamWin == i :
-                        teamDisplay.append("<table border=0 width = 100% height = 100%><tr><td align = 'center' valign='center' width =100%><font size ='+2'>WIN</font></td></tr></table>")
-                    else :
-                        teamDisplay.append("<table border=0 width = 100% height = 100%><tr><td align = 'center' valign='center' width =100%><font size ='+2'>LOSE</font></td></tr></table>")
+                if(len(self.teams[team]) > self.biggestTeam):
+                    self.biggestTeam = len(self.teams[team])
+
+                players = ""
                 for player in self.teams[team] :
-                    displayPlayer = ""
+                    alignment, playerIcon, playerLabel = self.generatePlayerHTML(i, player)
 
+                    if(player == self.winner and self.spoiled):
+                        winnerHTML = "<tr>%s%s</tr>" % (playerIcon, playerLabel)
+                    elif(alignment == "left" or alignment == "center"):
+                        players += "<tr>%s%s</tr>" % (playerIcon, playerLabel)
+                    else:
+                        players += "<tr>%s%s</tr>" % (playerLabel, playerIcon)
 
-                    playerStr = player["name"]
+                if(self.spoiled):
+                    if(self.winner != None):
+                        teams += self.FORMATTER_REPLAY_FFA_SPOILED.format(winner=winnerHTML, players=players)
+                    else:
+                        teamTitle = "Lose"
+                        if(self.teamWin == team):
+                            teamTitle = "Win"
 
-                    if "rating" in player :
-                        playerStr += " ("+str(int(player["rating"]))+")"
+                        teams += self.FORMATTER_REPLAY_TEAM_SPOILED.format(title= teamTitle, players = players)
+                else:
+                    teams += self.FORMATTER_REPLAY_TEAM.format(players = players)
 
-                    if "after_rating" in player and self.spoiled:
-                        playerStr += " to ("+str(int(player["after_rating"]))+")"
-
-
-                    if i == 1 and i != len(self.teams) :
-                        displayPlayer = ("<td align = 'left' valign='center' width=150>%s</td>" % playerStr)
-                    elif i == len(self.teams) :
-                        displayPlayer = ("<td align = 'right' valign='center' width=150>%s</td>" % playerStr)
-                    else :
-                        displayPlayer = ("<td align = 'center' valign='center' width=150>%s</td>" % playerStr)
-                    
-
-                    if "faction" in player :
-                        if player["faction"] == 1 :
-                            faction = "UEF"
-                        elif player["faction"] == 2 :
-                            faction = "Aeon"
-                        elif player["faction"] == 3 :
-                            faction = "Cybran"
-                        elif player["faction"] == 4 :
-                            faction = "Seraphim"                            
-                        elif player["faction"] == 5 :
-                            faction = "Nomads"     
-                        else :
-                            faction = "Broken"
-                            
-                        url = os.path.join(util.COMMON_DIR, "replays/%s.png" % faction)
- 
-                        if i == len(self.teams) : 
-                            displayPlayer += '<td width="40"><img src = "'+url+'" width="40" height="20"></td>'
-                        else :
-                            displayPlayer = '<td width="40"><img src = "'+url+'" width="40" height="20"></td>' + displayPlayer
-
-                    display = ("<tr>%s</tr>" % displayPlayer)
-
-                    teamDisplay.append(display)
-                        
-                members = "".join(teamDisplay)
-                
-                teamlist.append("<td>" + teamtxt + members + "</table></td>")
-                
-                    
-                
-            else :
-                observerlist.append(",".join(self.teams[team]))
-
-        teams += "<td valign='center' height='100%'><font valign='center' color='black' size='+5'>VS</font></td>".join(teamlist)
-
-
-        observers = ""
-        if len(observerlist) != 0 :
-            observers = "Observers : "
-            observers += ",".join(observerlist)    
+                if(i < len(self.teams)):
+                    teams += "<td valign='center' height='100%'><font valign='center' color='black' size='+5'>VS</font></td>"
 
         #self.setToolTip(teams)
-        self.replayInfo = ('<h2>Replay UID : %i</h2></br></br><table border="0" cellpadding="0" cellspacing="5"><tbody><tr>%s</tr></tbody></table>') % (self.uid, teams)
-        
-        
+        self.replayInfo = self.FORMATTER_REPLAY_INFORMATION.format(uid=self.uid, teams=teams)
+
         if self.isSelected() :
             self.parent.replayInfos.clear()
+            self.resize()
             self.parent.replayInfos.setHtml(self.replayInfo)
+
+    def generatePlayerHTML(self, i, player):
+        alignment = "left"
+        if i == len(self.teams) and len(self.teams) > 1:
+            alignment = "right"
+        if(i > 1 and i < len(self.teams)):
+            alignment = "left" #center if possible but it won't fill nice
+
+        playerLabel = self.FORMATTER_REPLAY_PLAYER_LABEL.format(player_name=player["name"],
+                                                                player_rating=player["rating"], alignment=alignment)
+
+        iconUrl = os.path.join(util.COMMON_DIR, "replays/%s.png" % self.retrieveIconFaction(player))
+
+        playerIcon = self.FORMATTER_REPLAY_PLAYER_ICON.format(faction_icon_uri=iconUrl)
+
+        return alignment, playerIcon, playerLabel
+
+    def retrieveIconFaction(self, player): #Factions does not contain Nomads
+        if "faction" in player:
+            if player["faction"] == 1:
+                faction = "UEF"
+            elif player["faction"] == 2:
+                faction = "Aeon"
+            elif player["faction"] == 3:
+                faction = "Cybran"
+            elif player["faction"] == 4:
+                faction = "Seraphim"
+            elif player["faction"] == 5:
+                faction = "Nomads"
+            else:
+                faction = "Broken"
+        return faction
+
+    def resize(self):
+        if(self.isSelected()):
+            if(self.extraInfoWidth == 0 or self.extraInfoHeight == 0):
+                self.extraInfoWidth = len(self.teams) * 200 + 150
+                self.extraInfoHeight = 100 + self.biggestTeam * 20
+                if(self.winner != None): self.extraInfoHeight += 40 #second title
+
+            self.parent.replayInfos.setMinimumWidth(self.extraInfoWidth)
+            self.parent.replayInfos.setMaximumWidth(self.extraInfoWidth)
+
+            self.parent.replayInfos.setMinimumHeight(self.extraInfoHeight)
+            self.parent.replayInfos.setMaximumHeight(self.extraInfoHeight)
 
 
     def pressed(self, item):


### PR DESCRIPTION
Rebased @TimWolters PR #328
- Changed UI in the Replayvault
- Split generateInfoPlayersHtml into different methods
- Moved HTML as much as possible to the top and in constants
- Added free-for-all in the extra information of the replay
- Removed observers from the extra information of the replay
- Removed after rating from extra information of the replay (in code)

Fixes #316
