### PR TITLE
Run appveyor without registry fix

### DIFF
--- a/appveyor/install_qt.py
+++ b/appveyor/install_qt.py
@@ -31,8 +31,8 @@ downloads = {
     'py27-pyqt4': 'PyQt4/PyQt-4.11.4/PyQt4-4.11.4-gpl-Py2.7-Qt4.8.7-x32.exe',
 }
 if 'INSTALL_QT' in os.environ:
-    fix_registry('34')
-    fix_registry('27')
+    #fix_registry('34')
+    #fix_registry('27')
     caption = os.environ['INSTALL_QT']
     url = downloads[caption]
     print("Downloading %s..." % caption)

--- a/appveyor/install_qt.py
+++ b/appveyor/install_qt.py
@@ -8,22 +8,6 @@ import os
 import subprocess
 import urllib
 
-
-def fix_registry(python_ver):
-    """Update install path on windows registry so PyQt installation installs at the correct
-    location.
-    python_ver must be "34", "27", etc.
-    """
-    import _winreg as winreg
-    python_dir = r'C:\Python%s' % python_ver
-    print("Fixing registry %s..." % python_ver)
-    assert os.path.isdir(python_dir)
-    registry_key = r'Software\Python\PythonCore\%s.%s' % (python_ver[0], python_ver[1])
-    with winreg.OpenKey(winreg.HKEY_CURRENT_USER,
-                        registry_key, 0,
-                        winreg.KEY_WRITE) as key:
-        winreg.SetValue(key, 'InstallPath', winreg.REG_SZ, python_dir)
-
 base_url = 'http://downloads.sourceforge.net/project/pyqt/'
 downloads = {
     'py34-pyqt5': 'PyQt5/PyQt-5.5/PyQt5-5.5-gpl-Py3.4-Qt5.5.0-x32.exe',
@@ -31,8 +15,6 @@ downloads = {
     'py27-pyqt4': 'PyQt4/PyQt-4.11.4/PyQt4-4.11.4-gpl-Py2.7-Qt4.8.7-x32.exe',
 }
 if 'INSTALL_QT' in os.environ:
-    #fix_registry('34')
-    #fix_registry('27')
     caption = os.environ['INSTALL_QT']
     url = downloads[caption]
     print("Downloading %s..." % caption)


### PR DESCRIPTION
This PR is intended to fix current build problems with appveyor regarding this error log:

`Build started
ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %QTIMPL%
C:\Python27 2.7.9 32 PyQt4
git clone -q --branch=develop https://github.com/FAForever/client.git C:\projects\client
git checkout -qf 1abb986167e81fd18c4dddd70713d2ae02be84a1
Running Install scripts
C:\Python27\python -u appveyor\install_qt.py
Fixing registry 34...
Traceback (most recent call last):
  File "appveyor\install_qt.py", line 34, in <module>
    fix_registry('34')
  File "appveyor\install_qt.py", line 24, in fix_registry
    winreg.KEY_WRITE) as key:
WindowsError: [Error 2] The system cannot find the file specified
Command exited with code 1`
