### PR TITLE
Move ConnectivityHelper to separate thread

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from PyQt4.QtCore import QUrl
+from PyQt4.QtCore import QUrl, pyqtSignal
 from PyQt4.QtGui import QLabel, QStyle
 from PyQt4.QtNetwork import QAbstractSocket
 
@@ -94,49 +94,49 @@ class ClientWindow(FormClass, BaseClass):
     topWidget = QtGui.QWidget()
 
     # These signals are emitted when the client is connected or disconnected from FAF
-    connected = QtCore.pyqtSignal()
-    authorized = QtCore.pyqtSignal(object)
-    disconnected = QtCore.pyqtSignal()
+    connected = pyqtSignal()
+    authorized = pyqtSignal(object)
+    disconnected = pyqtSignal()
 
-    state_changed = QtCore.pyqtSignal(object)
+    state_changed = pyqtSignal(object)
 
     # This signal is emitted when the client is done rezising
-    doneresize = QtCore.pyqtSignal()
+    doneresize = pyqtSignal()
 
     # These signals notify connected modules of game state changes (i.e. reasons why FA is launched)
-    viewingReplay = QtCore.pyqtSignal(QtCore.QUrl)
+    viewingReplay = pyqtSignal(QtCore.QUrl)
 
     # Game state controls
-    gameEnter = QtCore.pyqtSignal()
-    gameExit = QtCore.pyqtSignal()
+    gameEnter = pyqtSignal()
+    gameExit = pyqtSignal()
 
     # These signals propagate important client state changes to other modules
-    statsInfo = QtCore.pyqtSignal(dict)
-    tutorialsInfo = QtCore.pyqtSignal(dict)
-    modInfo = QtCore.pyqtSignal(dict)
-    gameInfo = QtCore.pyqtSignal(dict)
-    modVaultInfo = QtCore.pyqtSignal(dict)
-    coopInfo = QtCore.pyqtSignal(dict)
-    avatarList = QtCore.pyqtSignal(list)
-    playerAvatarList = QtCore.pyqtSignal(dict)
-    usersUpdated = QtCore.pyqtSignal(list)
-    localBroadcast = QtCore.pyqtSignal(str, str)
-    autoJoin = QtCore.pyqtSignal(list)
-    channelsUpdated = QtCore.pyqtSignal(list)
-    replayVault = QtCore.pyqtSignal(dict)
-    coopLeaderBoard = QtCore.pyqtSignal(dict)
+    statsInfo = pyqtSignal(dict)
+    tutorialsInfo = pyqtSignal(dict)
+    modInfo = pyqtSignal(dict)
+    gameInfo = pyqtSignal(dict)
+    modVaultInfo = pyqtSignal(dict)
+    coopInfo = pyqtSignal(dict)
+    avatarList = pyqtSignal(list)
+    playerAvatarList = pyqtSignal(dict)
+    usersUpdated = pyqtSignal(list)
+    localBroadcast = pyqtSignal(str, str)
+    autoJoin = pyqtSignal(list)
+    channelsUpdated = pyqtSignal(list)
+    replayVault = pyqtSignal(dict)
+    coopLeaderBoard = pyqtSignal(dict)
 
     # These signals are emitted whenever a certain tab is activated
-    showReplays = QtCore.pyqtSignal()
-    showMaps = QtCore.pyqtSignal()
-    showGames = QtCore.pyqtSignal()
-    showTourneys = QtCore.pyqtSignal()
-    showLadder = QtCore.pyqtSignal()
-    showChat = QtCore.pyqtSignal()
-    showMods = QtCore.pyqtSignal()
-    showCoop = QtCore.pyqtSignal()
+    showReplays = pyqtSignal()
+    showMaps = pyqtSignal()
+    showGames = pyqtSignal()
+    showTourneys = pyqtSignal()
+    showLadder = pyqtSignal()
+    showChat = pyqtSignal()
+    showMods = pyqtSignal()
+    showCoop = pyqtSignal()
 
-    matchmakerInfo = QtCore.pyqtSignal(dict)
+    matchmakerInfo = pyqtSignal(dict)
 
     remember = Settings.persisted_property('user/remember', type=bool, default_value=True)
     login = Settings.persisted_property('user/login', persist_if=lambda self: self.remember)

--- a/src/connectivity/relay.py
+++ b/src/connectivity/relay.py
@@ -22,7 +22,6 @@ class Relay(QObject):
         self._socket.bind()
 
     def send(self, message):
-        self._logger.debug("game at 127.0.0.1:{}<<{} len: {}".format(self.game_port, self.peer_id, len(message)))
         self._socket.writeDatagram(message, QHostAddress.LocalHost, self.game_port)
 
     def _state_changed(self, state):
@@ -32,5 +31,4 @@ class Relay(QObject):
     def _ready_read(self):
         while self._socket.hasPendingDatagrams():
             data, host, port = self._socket.readDatagram(self._socket.pendingDatagramSize())
-            self._logger.debug("{}>>{}/{}".format(self._socket.localPort(), self.login, self.peer_id))
             self.recv(data)

--- a/src/fa/game_session.py
+++ b/src/fa/game_session.py
@@ -51,7 +51,6 @@ class GameSession(QObject):
         self.me = client.me
 
         self.game_port = client.gamePort
-        self.player = client.me
 
         # Use the normal lobby by default
         self.init_mode = 0

--- a/src/fa/game_session.py
+++ b/src/fa/game_session.py
@@ -159,10 +159,6 @@ class GameSession(QObject):
 
         self.send(command, args)
 
-    def _turn_state_changed(self, val):
-        if val == TURNState.BOUND:
-            self.ready.emit()
-
     def _launched(self):
         self._logger.info("Game has started")
 

--- a/src/fa/game_session.py
+++ b/src/fa/game_session.py
@@ -1,4 +1,4 @@
-from PyQt4.QtCore import QObject, pyqtSignal
+from PyQt4.QtCore import QObject, pyqtSignal,  QMetaObject, Q_ARG, Qt
 from PyQt4.QtNetwork import QTcpServer, QHostAddress
 from enum import IntEnum
 
@@ -89,31 +89,23 @@ class GameSession(QObject):
         """
         assert self.state == GameSessionState.OFF
         self.state = GameSessionState.LISTENING
-        if self.connectivity.is_ready:
-            self.ready.emit()
-        else:
-            self.connectivity.prepare()
+
+        # prepare() will emit 'ready' when done
+        self.connectivity.metaObject().invokeMethod(self.connectivity, "prepare", Qt.QueuedConnection)
 
     def handle_message(self, message):
         command, args = message.get('command'), message.get('args', [])
-        if command == 'SendNatPacket':
-            addr_and_port, message = args
-            host, port = addr_and_port.split(':')
-            self.connectivity.send(message, (host, port))
-        elif command == 'CreatePermission':
-            addr_and_port = args[0]
-            host, port = addr_and_port.split(':')
-            self.connectivity.permit((host, port))
-        elif command == 'JoinGame':
+
+        if command == 'JoinGame':
             addr, login, peer_id = args
             self._joins.append(peer_id)
-            self.connectivity.bind(addr, login, peer_id)
         elif command == 'ConnectToPeer':
             addr, login, peer_id = args
             self._connects.append(peer_id)
-            self.connectivity.bind(addr, login, peer_id)
         else:
             self._game_connection.send(command, *args)
+
+        self.connectivity.metaObject().invokeMethod(self.connectivity, "handle_game_message", Qt.QueuedConnection, Q_ARG(dict, message))
 
     def send(self, command_id, args):
         self._logger.info("Outgoing relay message {} {}".format(command_id, args))


### PR DESCRIPTION
Seems to be a good idea to move ConnectivityHelper to a separate thread .This way we don't care if the GUI locks up and it will also reduce jitter / latency when relaying the in-game packets.

Hopefully fixes #348 (Outbound traffic error) et al.

(needs testing, I'll run a couple of games later this week with this patch)
