### PR TITLE
Replays tab UI change for performance gain

### DIFF
--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -433,7 +433,6 @@ class ReplaysWidget(BaseClass, FormClass):
                         playeritem.setDisabled(True)
 
                     item.addChild(playeritem)
-                    self.liveTree.setFirstItemColumnSpanned(playeritem, True)
         elif info['state'] == "closed":
             if info['uid'] in self.games:
                 self.liveTree.takeTopLevelItem(self.liveTree.indexOfTopLevelItem(self.games[info['uid']]))


### PR DESCRIPTION
This is what I got when profiling the code:
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    1794   20.571    0.011   20.571    0.011 {built-in method setFirstItemColumnSpanned}

This was when I started up the client, which took ~30 secs.

I already killed one of these calls (see https://github.com/FAForever/client/commit/3f5d946151ca634f8d8de383af91a0745d7cf0c8 ), but must have missed this one.
