### PR TITLE
paths adjustments for linux support 

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,14 +30,16 @@ uic.widgetPluginPath.append(path)
 if getattr(sys, 'frozen', False):
     os.chdir(os.path.dirname(sys.executable))
 else:
-    # We are most likely running from source
-    srcDir = os.path.dirname(os.path.relpath(__file__))
-    devRoot = os.path.abspath(os.path.join(srcDir, os.pardir))
-    os.chdir(devRoot)
-    # We need to set the working directory correctly.
+    if sys.platform == 'win32':
+        # We are most likely running from source
+        srcDir = os.path.dirname(os.path.relpath(__file__))
+        devRoot = os.path.abspath(os.path.join(srcDir, os.pardir))
+        os.chdir(devRoot)
+        # We need to set the working directory correctly.
 
 import util
-util.COMMON_DIR = os.path.join(os.getcwd(), "res")
+if sys.platform == 'win32':
+    util.COMMON_DIR = os.path.join(os.getcwd(), "res")
 
 # Set up crash reporting
 excepthook_original = sys.excepthook


### PR DESCRIPTION
squash of 
4e289b0c5a624732d444245eabf86f6119b5fdac
9484497cc11a21e34428a6a16742df5d6e85c56f
f6f897f3f1c8bc8569f36b7ade09d2c92c6cd54a and
51cde72ff2305b13a35ad0228260685750155d2f

as requested in #446

adjust COMMON_DIR and PERSONAL_DIR
prevent COMMON_DIR and CWD twisting on Linux
fix COMMON_DIR, LOCALFOLDER, PREFSFILENAME and PERSONAL_DIR
make PERSONAL_DIR python string