### PR TITLE
Fix codestyle of map files

### DIFF
--- a/src/fa/maps.py
+++ b/src/fa/maps.py
@@ -1,84 +1,87 @@
+# system imports
 import logging
 import string
 import sys
 from urllib2 import HTTPError
-import fa
-
-logger= logging.getLogger(__name__)
-
 from PyQt4 import QtCore, QtGui, QtNetwork
 import cStringIO
 import util
-import os, stat
+import os
+import stat
 import struct
 import shutil
 import urllib2
 import zipfile
 import tempfile
 import re
+# module imports
+import fa
+# local imports
 from config import Settings
+
+logger = logging.getLogger(__name__)
 
 route = Settings.get('content/host')
 VAULT_PREVIEW_ROOT = "{}/faf/vault/map_previews/small/".format(route)
 VAULT_DOWNLOAD_ROOT = "{}/faf/vault/".format(route)
 VAULT_COUNTER_ROOT = "{}/faf/vault/map_vault/inc_downloads.php".format(route)
- 
+
 maps = { # A Lookup table for info (names, sizes, players) of the official Forged Alliance Maps
-                 "scmp_001" : ["Burial Mounds", "1024x1024", 8],
-                 "scmp_002" : ["Concord Lake", "1024x1024", 8],
-                 "scmp_003" : ["Drake's Ravine", "1024x1024", 4],
-                 "scmp_004" : ["Emerald Crater", "1024x1024", 4],
-                 "scmp_005" : ["Gentleman's Reef", "2048x2048", 7],
-                 "scmp_006" : ["Ian's Cross", "1024x1024", 4],
-                 "scmp_007" : ["Open Palms", "512x512", 6],
-                 "scmp_008" : ["Seraphim Glaciers", "1024x1024", 8],
-                 "scmp_009" : ["Seton's Clutch", "1024x1024", 8],
-                 "scmp_010" : ["Sung Island", "1024x1024", 5],
-                 "scmp_011" : ["The Great Void", "2048x2048", 8],
-                 "scmp_012" : ["Theta Passage", "256x256", 2],
-                 "scmp_013" : ["Winter Duel", "256x256", 2],
-                 "scmp_014" : ["The Bermuda Locket", "1024x1024", 8],
-                 "scmp_015" : ["Fields Of Isis", "512x512", 4],
-                 "scmp_016" : ["Canis River", "256x256", 2],
-                 "scmp_017" : ["Syrtis Major", "512x512", 4],
-                 "scmp_018" : ["Sentry Point", "256x256", 3],
-                 "scmp_019" : ["Finn's Revenge", "512x512", 2],
-                 "scmp_020" : ["Roanoke Abyss", "1024x1024", 6],
-                 "scmp_021" : ["Alpha 7 Quarantine", "2048x2048", 8],
-                 "scmp_022" : ["Artic Refuge", "512x512", 4],
-                 "scmp_023" : ["Varga Pass", "512x512", 2],
-                 "scmp_024" : ["Crossfire Canal", "1024x1024", 6],
-                 "scmp_025" : ["Saltrock Colony", "512x512", 6],
-                 "scmp_026" : ["Vya-3 Protectorate", "512x512", 4],
-                 "scmp_027" : ["The Scar", "1024x1024", 6],
-                 "scmp_028" : ["Hanna oasis", "2048x2048", 8],
-                 "scmp_029" : ["Betrayal Ocean", "4096x4096", 8],
-                 "scmp_030" : ["Frostmill Ruins", "4096x4096", 8],
-                 "scmp_031" : ["Four-Leaf Clover", "512x512", 4],
-                 "scmp_032" : ["The Wilderness", "512x512", 4],
-                 "scmp_033" : ["White Fire", "512x512", 6],
-                 "scmp_034" : ["High Noon", "512x512", 4],
-                 "scmp_035" : ["Paradise", "512x512", 4],
-                 "scmp_036" : ["Blasted Rock", "256x256", 4],
-                 "scmp_037" : ["Sludge", "256x256", 3],
-                 "scmp_038" : ["Ambush Pass", "256x256", 4],
-                 "scmp_039" : ["Four-Corners", "256x256", 4],
-                 "scmp_040" : ["The Ditch", "1024x1024", 6],
-                 "x1mp_001" : ["Crag Dunes", "256x256", 2],
-                 "x1mp_002" : ["Williamson's Bridge", "256x256", 2],
-                 "x1mp_003" : ["Snoey Triangle", "512x512", 3],
-                 "x1mp_004" : ["Haven Reef", "512x512", 4],
-                 "x1mp_005" : ["The Dark Heart", "512x512", 6],
-                 "x1mp_006" : ["Daroza's Sanctuary", "512x512", 4],
-                 "x1mp_007" : ["Strip Mine", "1024x1024", 4],
-                 "x1mp_008" : ["Thawing Glacier", "1024x1024", 6],
-                 "x1mp_009" : ["Liberiam Battles", "1024x1024", 8],
-                 "x1mp_010" : ["Shards", "2048x2048", 8],
-                 "x1mp_011" : ["Shuriken Island", "2048x2048", 8],
-                 "x1mp_012" : ["Debris", "4096x4096", 8],
-                 "x1mp_014" : ["Flooded Strip Mine", "1024x1024", 4],
-                 "x1mp_017" : ["Eye Of The Storm", "512x512", 4],
-                 }
+    "scmp_001" : ["Burial Mounds", "1024x1024", 8],
+    "scmp_002" : ["Concord Lake", "1024x1024", 8],
+    "scmp_003" : ["Drake's Ravine", "1024x1024", 4],
+    "scmp_004" : ["Emerald Crater", "1024x1024", 4],
+    "scmp_005" : ["Gentleman's Reef", "2048x2048", 7],
+    "scmp_006" : ["Ian's Cross", "1024x1024", 4],
+    "scmp_007" : ["Open Palms", "512x512", 6],
+    "scmp_008" : ["Seraphim Glaciers", "1024x1024", 8],
+    "scmp_009" : ["Seton's Clutch", "1024x1024", 8],
+    "scmp_010" : ["Sung Island", "1024x1024", 5],
+    "scmp_011" : ["The Great Void", "2048x2048", 8],
+    "scmp_012" : ["Theta Passage", "256x256", 2],
+    "scmp_013" : ["Winter Duel", "256x256", 2],
+    "scmp_014" : ["The Bermuda Locket", "1024x1024", 8],
+    "scmp_015" : ["Fields Of Isis", "512x512", 4],
+    "scmp_016" : ["Canis River", "256x256", 2],
+    "scmp_017" : ["Syrtis Major", "512x512", 4],
+    "scmp_018" : ["Sentry Point", "256x256", 3],
+    "scmp_019" : ["Finn's Revenge", "512x512", 2],
+    "scmp_020" : ["Roanoke Abyss", "1024x1024", 6],
+    "scmp_021" : ["Alpha 7 Quarantine", "2048x2048", 8],
+    "scmp_022" : ["Artic Refuge", "512x512", 4],
+    "scmp_023" : ["Varga Pass", "512x512", 2],
+    "scmp_024" : ["Crossfire Canal", "1024x1024", 6],
+    "scmp_025" : ["Saltrock Colony", "512x512", 6],
+    "scmp_026" : ["Vya-3 Protectorate", "512x512", 4],
+    "scmp_027" : ["The Scar", "1024x1024", 6],
+    "scmp_028" : ["Hanna oasis", "2048x2048", 8],
+    "scmp_029" : ["Betrayal Ocean", "4096x4096", 8],
+    "scmp_030" : ["Frostmill Ruins", "4096x4096", 8],
+    "scmp_031" : ["Four-Leaf Clover", "512x512", 4],
+    "scmp_032" : ["The Wilderness", "512x512", 4],
+    "scmp_033" : ["White Fire", "512x512", 6],
+    "scmp_034" : ["High Noon", "512x512", 4],
+    "scmp_035" : ["Paradise", "512x512", 4],
+    "scmp_036" : ["Blasted Rock", "256x256", 4],
+    "scmp_037" : ["Sludge", "256x256", 3],
+    "scmp_038" : ["Ambush Pass", "256x256", 4],
+    "scmp_039" : ["Four-Corners", "256x256", 4],
+    "scmp_040" : ["The Ditch", "1024x1024", 6],
+    "x1mp_001" : ["Crag Dunes", "256x256", 2],
+    "x1mp_002" : ["Williamson's Bridge", "256x256", 2],
+    "x1mp_003" : ["Snoey Triangle", "512x512", 3],
+    "x1mp_004" : ["Haven Reef", "512x512", 4],
+    "x1mp_005" : ["The Dark Heart", "512x512", 6],
+    "x1mp_006" : ["Daroza's Sanctuary", "512x512", 4],
+    "x1mp_007" : ["Strip Mine", "1024x1024", 4],
+    "x1mp_008" : ["Thawing Glacier", "1024x1024", 6],
+    "x1mp_009" : ["Liberiam Battles", "1024x1024", 8],
+    "x1mp_010" : ["Shards", "2048x2048", 8],
+    "x1mp_011" : ["Shuriken Island", "2048x2048", 8],
+    "x1mp_012" : ["Debris", "4096x4096", 8],
+    "x1mp_014" : ["Flooded Strip Mine", "1024x1024", 4],
+    "x1mp_017" : ["Eye Of The Storm", "512x512", 4],
+}
 
 __exist_maps = None
 
@@ -92,22 +95,22 @@ def isBase(mapname):
 
 def getUserMaps():
     maps = []
-    if os.path.isdir(getUserMapsFolder()) :
-            maps = os.listdir(getUserMapsFolder())
+    if os.path.isdir(getUserMapsFolder()):
+        maps = os.listdir(getUserMapsFolder())
     return maps
 
 def getDisplayName(filename):
     '''
     Tries to return a pretty name for the map (for official maps, it looks up the name)
     For nonofficial maps, it tries to clean up the filename
-    '''      
-    if str(filename) in maps :
+    '''
+    if str(filename) in maps:
         return maps[filename][0]
-    else :
+    else:
         #cut off ugly version numbers, replace "_" with space.
-        pretty = filename.rsplit(".v0",1)[0]
+        pretty = filename.rsplit(".v0", 1)[0]
         pretty = pretty.replace("_", " ")
-        pretty = string.capwords(pretty)  
+        pretty = string.capwords(pretty)
         return pretty
 
 def name2link(name):
@@ -126,21 +129,21 @@ def link2name(link):
     return name
 
 def getScenarioFile(folder):
-    ''' 
+    '''
     Return the scenario.lua file
     '''
-    for infile in os.listdir(folder) :
-        if infile.lower().endswith("_scenario.lua") :
-            return infile 
+    for infile in os.listdir(folder):
+        if infile.lower().endswith("_scenario.lua"):
+            return infile
     return None
 
 def getSaveFile(folder):
-    ''' 
+    '''
     Return the save.lua file
     '''
-    for infile in os.listdir(folder) :
-        if infile.lower().endswith("_save.lua") :
-            return infile 
+    for infile in os.listdir(folder):
+        if infile.lower().endswith("_save.lua"):
+            return infile
     return None
 
 def isMapFolderValid(folder):
@@ -159,19 +162,19 @@ def isMapFolderValid(folder):
     return files_required.issubset(files_present)
 
 
-def existMaps(force = False):
+def existMaps(force=False):
     global __exist_maps
-    if force or __exist_maps == None:
-        
+    if force or __exist_maps is None:
+
         __exist_maps = getUserMaps()
 
-        if os.path.isdir(getBaseMapsFolder()) :
-            if __exist_maps == None :
+        if os.path.isdir(getBaseMapsFolder()):
+            if __exist_maps is None:
                 __exist_maps = os.listdir(getBaseMapsFolder())
-            else : 
+            else:
                 __exist_maps.extend(os.listdir(getBaseMapsFolder()))
-    return __exist_maps        
-    
+    return __exist_maps
+
 
 
 def isMapAvailable(mapname):
@@ -180,13 +183,13 @@ def isMapAvailable(mapname):
     '''
     if isBase(mapname):
         return True
-    
+
     if os.path.isdir(getUserMapsFolder()):
-        for infile in os.listdir(getUserMapsFolder()) :
-            if infile.lower() == mapname.lower(): 
+        for infile in os.listdir(getUserMapsFolder()):
+            if infile.lower() == mapname.lower():
                 return True
 
-    return False    
+    return False
 
 def folderForMap(mapname):
     '''
@@ -194,10 +197,10 @@ def folderForMap(mapname):
     '''
     if isBase(mapname):
         return os.path.join(getBaseMapsFolder(), mapname)
-    
+
     if os.path.isdir(getUserMapsFolder()):
-        for infile in os.listdir(getUserMapsFolder()) :
-            if infile.lower() == mapname.lower(): 
+        for infile in os.listdir(getUserMapsFolder()):
+            if infile.lower() == mapname.lower():
                 return os.path.join(getUserMapsFolder(), mapname)
 
     return None
@@ -211,23 +214,28 @@ def getBaseMapsFolder():
         return os.path.join(gamepath, "maps")
     else:
         return "maps" #This most likely isn't the valid maps folder, but it's the best guess.
- 
- 
+
+
 def getUserMapsFolder():
     '''
     Returns to folder where the downloaded maps of the user are stored.
     '''
-    return os.path.join(util.PERSONAL_DIR, "My Games", "Gas Powered Games", "Supreme Commander Forged Alliance", "Maps") 
+    return os.path.join(
+        util.PERSONAL_DIR,
+        "My Games",
+        "Gas Powered Games",
+        "Supreme Commander Forged Alliance",
+        "Maps")
 
 
-def genPrevFromDDS(sourcename, destname,small=False):
+def genPrevFromDDS(sourcename, destname, small=False):
     '''
     this opens supcom's dds file (format: bgra8888) and saves to png
     '''
     try:
         img = bytearray()
         buf = bytearray(16)
-        file = open(sourcename,"rb")
+        file = open(sourcename, "rb")
         file.seek(128) # skip header
         while file.readinto(buf):
             img += buf[:3] + buf[4:7] + buf[8:11] + buf[12:15]
@@ -235,9 +243,20 @@ def genPrevFromDDS(sourcename, destname,small=False):
 
         size = int((len(img)/3) ** (1.0/2))
         if small:
-            imageFile = QtGui.QImage(img,size,size,QtGui.QImage.Format_RGB888).rgbSwapped().scaled(100,100,transformMode = QtCore.Qt.SmoothTransformation)
+            imageFile = QtGui.QImage(
+                img,
+                size,
+                size,
+                QtGui.QImage.Format_RGB888).rgbSwapped().scaled(
+                    100,
+                    100,
+                    transformMode=QtCore.Qt.SmoothTransformation)
         else:
-            imageFile = QtGui.QImage(img,size,size,QtGui.QImage.Format_RGB888).rgbSwapped()
+            imageFile = QtGui.QImage(
+                img,
+                size,
+                size,
+                QtGui.QImage.Format_RGB888).rgbSwapped()
         imageFile.save(destname)
     except IOError:
         pass # cant open the
@@ -246,13 +265,13 @@ def __exportPreviewFromMap(mapname, positions=None):
     '''
     This method auto-upgrades the maps to have small and large preview images
     '''
-    if mapname == "" or mapname == None:
+    if mapname is None or mapname == "":
         return
     smallExists = False
     largeExists = False
     ddsExists = False
     previews = {"cache":None, "tozip":list()}
-    
+
     if os.path.isdir(mapname):
         mapdir = mapname
     elif os.path.isdir(os.path.join(getUserMapsFolder(), mapname)):
@@ -262,10 +281,10 @@ def __exportPreviewFromMap(mapname, positions=None):
     else:
         logger.debug("Can't find mapname in file system: " + mapname)
         return previews
-        
+
     mapname = os.path.basename(mapdir).lower()
     mapfilename = os.path.join(mapdir, mapname.split(".")[0]+".scmap")
-    
+
     mode = os.stat(mapdir)[0]
     if not (mode and stat.S_IWRITE):
         logger.debug("Map directory is not writable: " + mapdir)
@@ -273,18 +292,21 @@ def __exportPreviewFromMap(mapname, positions=None):
         mapdir = os.path.join(util.CACHE_DIR, mapname)
         if not os.path.isdir(mapdir):
             os.mkdir(mapdir)
-    
+
     previewsmallname = os.path.join(mapdir, mapname + ".small.png")
     previewlargename = os.path.join(mapdir, mapname + ".large.png")
     previewddsname = os.path.join(mapdir, mapname + ".dds")
     cachepngname = os.path.join(util.CACHE_DIR, mapname + ".png")
-        
+
     logger.debug("Generating preview from user maps for: " + mapname)
     logger.debug("Using directory: " + mapdir)
-    
-    #Unknown / Unavailable mapname? 
+
+    #Unknown / Unavailable mapname?
     if not os.path.isfile(mapfilename):
-        logger.warning("Unable to find the .scmap for: " + mapname + ", was looking here: " + mapfilename)
+        logger.warning(
+            "Unable to find the .scmap for: {}, was looking here: {}".format(
+                mapname, mapfilename
+                ))
         return previews
 
     #Small preview already exists?
@@ -300,7 +322,7 @@ def __exportPreviewFromMap(mapname, positions=None):
         else:
             logger.debug("Couldn't copy preview into cache folder")
             return previews
-        
+
     #Large preview already exists?
     if os.path.isfile(previewlargename):
         logger.debug(mapname + " already has large preview")
@@ -312,13 +334,13 @@ def __exportPreviewFromMap(mapname, positions=None):
         logger.debug(mapname + " already has DDS extracted")
         previews["tozip"].append(previewddsname)
         ddsExists = True
-    
+
     if not ddsExists:
         logger.debug("Extracting preview DDS from .scmap for: " + mapname)
         mapfile = open(mapfilename, "rb")
         """
-        magic = struct.unpack('i', mapfile.read(4))[0]       
-        version_major = struct.unpack('i', mapfile.read(4))[0]       
+        magic = struct.unpack('i', mapfile.read(4))[0]
+        version_major = struct.unpack('i', mapfile.read(4))[0]
         unk_edfe = struct.unpack('i', mapfile.read(4))[0]
         unk_efbe = struct.unpack('i', mapfile.read(4))[0]
         width = struct.unpack('f', mapfile.read(4))[0]
@@ -329,7 +351,7 @@ def __exportPreviewFromMap(mapname, positions=None):
         mapfile.seek(30)    #Shortcut. Maybe want to clean out some of the magic numbers some day
         size = struct.unpack('i', mapfile.read(4))[0]
         data = mapfile.read(size)
-        #version_minor = struct.unpack('i', mapfile.read(4))[0]   
+        #version_minor = struct.unpack('i', mapfile.read(4))[0]
         mapfile.close()
         #logger.debug("SCMAP version %i.%i" % (version_major, version_minor))
 
@@ -345,16 +367,16 @@ def __exportPreviewFromMap(mapname, positions=None):
                     return previews
         except IOError:
             pass
-    
+
     if not smallExists:
         logger.debug("Making small preview from DDS for: " + mapname)
-        genPrevFromDDS(previewddsname,previewsmallname,small=True)
+        genPrevFromDDS(previewddsname, previewsmallname, small=True)
         if os.path.isfile(previewsmallname):
             previews["tozip"].append(previewsmallname)
         else:
             logger.debug("Failed to make small preview for: " + mapname)
             return previews
-        
+
         shutil.copyfile(previewsmallname, cachepngname)
         #checking if file was copied correctly, just in case
         if os.path.isfile(cachepngname):
@@ -362,7 +384,7 @@ def __exportPreviewFromMap(mapname, positions=None):
         else:
             logger.debug("Failed to write in cache folder")
             return previews
-    
+
     if not largeExists:
         logger.debug("Making large preview from DDS for: " + mapname)
         if not isinstance(positions, dict):
@@ -373,29 +395,37 @@ def __exportPreviewFromMap(mapname, positions=None):
         armyicon = util.pixmap("vault/map_icons/army.png").scaled(8, 9, 1, 1)
         massicon = util.pixmap("vault/map_icons/mass.png").scaled(8, 8, 1, 1)
         hydroicon = util.pixmap("vault/map_icons/hydro.png").scaled(10, 10, 1, 1)
-        
-        
+
+
         painter = QtGui.QPainter()
-        
+
         painter.begin(mapimage)
-        #icons should be drawn in certain order: first layer is hydros, second - mass, and army on top. made so that previews not look messed up.
+        # icons should be drawn in certain order: first layer is hydros,
+        # second - mass, and army on top. made so that previews not
+        # look messed up.
         if positions.has_key("hydro"):
             for pos in positions["hydro"]:
-                target = QtCore.QRectF(positions["hydro"][pos][0]-5, positions["hydro"][pos][1]-5, 10, 10)
+                target = QtCore.QRectF(
+                    positions["hydro"][pos][0]-5,
+                    positions["hydro"][pos][1]-5, 10, 10)
                 source = QtCore.QRectF(0.0, 0.0, 10.0, 10.0)
                 painter.drawPixmap(target, hydroicon, source)
         if positions.has_key("mass"):
             for pos in positions["mass"]:
-                target = QtCore.QRectF(positions["mass"][pos][0]-4, positions["mass"][pos][1]-4, 8, 8)
+                target = QtCore.QRectF(
+                    positions["mass"][pos][0]-4,
+                    positions["mass"][pos][1]-4, 8, 8)
                 source = QtCore.QRectF(0.0, 0.0, 8.0, 8.0)
                 painter.drawPixmap(target, massicon, source)
         if positions.has_key("army"):
             for pos in positions["army"]:
-                target = QtCore.QRectF(positions["army"][pos][0]-4, positions["army"][pos][1]-4, 8, 9)
+                target = QtCore.QRectF(
+                    positions["army"][pos][0]-4,
+                    positions["army"][pos][1]-4, 8, 9)
                 source = QtCore.QRectF(0.0, 0.0, 8.0, 9.0)
                 painter.drawPixmap(target, armyicon, source)
         painter.end()
-        
+
         mapimage.save(previewlargename)
         #checking if file was created correctly, just in case
         if os.path.isfile(previewlargename):
@@ -412,35 +442,39 @@ def __downloadPreviewFromWeb(name):
     '''
     Downloads a preview image from the web for the given map name
     '''
-    #This is done so generated previews always have a lower case name. This doesn't solve the underlying problem (case folding Windows vs. Unix vs. FAF)
+    # This is done so generated previews always have a lower case name.
+    # This doesn't solve the underlying problem
+    # (case folding Windows vs. Unix vs. FAF)
     name = name.lower()
 
     logger.debug("Searching web preview for: " + name)
-        
+
     for extension in iconExtensions:
         try:
-            header = urllib2.Request(VAULT_PREVIEW_ROOT + urllib2.quote(name) + "." + extension, headers={'User-Agent' : "FAF Client"})   
+            header = urllib2.Request(
+                VAULT_PREVIEW_ROOT + urllib2.quote(name) + "." + extension,
+                headers={'User-Agent' : "FAF Client"})
             req = urllib2.urlopen(header)
             img = os.path.join(util.CACHE_DIR, name + "." + extension)
             with open(img, 'wb') as fp:
                 shutil.copyfileobj(req, fp)
                 fp.flush()
-                os.fsync(fp.fileno())       #probably works fine without the flush and fsync
+                os.fsync(fp.fileno())       # probably works fine without the flush and fsync
                 fp.close()
-                
-                #Create alpha-mapped preview image
+
+                # Create alpha-mapped preview image
                 im = QtGui.QImage(img) #.scaled(100,100)
                 im.save(img)
                 logger.debug("Web Preview " + extension + " used for: " + name)
                 return img
         except:
             logger.error("Web preview download failed for " + name)
-        
+
     logger.error("Web Preview not found for: " + name)
     return None
 
 
-def preview(mapname, pixmap = False):
+def preview(mapname, pixmap=False):
     try:
         # Try to load directly from cache
         for extension in iconExtensions:
@@ -449,9 +483,9 @@ def preview(mapname, pixmap = False):
                 logger.debug("Using cached preview image for: " + mapname)
                 return util.icon(img, False, pixmap)
 
-        # Try to find in local map folder    
+        # Try to find in local map folder
         img = __exportPreviewFromMap(mapname)
-       
+
         if img and 'cache' in img and img['cache'] and os.path.isfile(img['cache']):
             logger.debug("Using fresh preview image for: " + mapname)
             return util.icon(img['cache'], False, pixmap)
@@ -515,7 +549,7 @@ class Downloader(QtCore.QObject):
 
 
 def downloadMap(name, silent=False):
-    ''' 
+    '''
     Download a map from the vault with the given name
     LATER: This type of method is so common, it could be put into a nice util method.
     '''
@@ -528,30 +562,30 @@ def downloadMap(name, silent=False):
         progress.setCancelButtonText("Cancel")
     else:
         progress.setCancelButton(None)
-        
+
     progress.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint)
     progress.setAutoClose(False)
     progress.setAutoReset(False)
-       
-    
+
+
     try:
-        req = urllib2.Request(url, headers={'User-Agent' : "FAF Client"})         
-        zipwebfile  = urllib2.urlopen(req)
+        req = urllib2.Request(url, headers={'User-Agent' : "FAF Client"})
+        zipwebfile = urllib2.urlopen(req)
         meta = zipwebfile.info()
         file_size = int(meta.getheaders("Content-Length")[0])
 
-        
+
         progress.setMinimum(0)
         progress.setMaximum(file_size)
         progress.setModal(1)
         progress.setWindowTitle("Downloading Map")
         progress.setLabelText(name)
         progress.show()
-    
+
         #Download the file as a series of 8 KiB chunks, then uncompress it.
         output = cStringIO.StringIO()
         file_size_dl = 0
-        block_sz = 8192       
+        block_sz = 8192
 
         while progress.isVisible():
             read_buffer = zipwebfile.read(block_sz)
@@ -560,13 +594,13 @@ def downloadMap(name, silent=False):
             file_size_dl += len(read_buffer)
             output.write(read_buffer)
             progress.setValue(file_size_dl)
-    
+
         progress.close()
         if file_size_dl == file_size:
             zfile = zipfile.ZipFile(output)
             zfile.extractall(getUserMapsFolder())
             zfile.close()
-                
+
             logger.debug("Successfully downloaded and extracted map from: " + url)
         else:
             logger.warn("Map download cancelled for: " + url)
@@ -575,11 +609,19 @@ def downloadMap(name, silent=False):
     except:
         logger.warn("Map download or extraction failed for: " + url)
         if sys.exc_type is HTTPError:
-            logger.warning("Vault download failed with HTTPError, map probably not in vault (or broken).")
-            QtGui.QMessageBox.information(None, "Map not downloadable", "<b>This map was not found in the vault (or is broken).</b><br/>You need to get it from somewhere else in order to use it." )
+            logger.warning("Vault download failed with HTTPError,"\
+                " map probably not in vault (or broken).")
+            QtGui.QMessageBox.information(
+                None,
+                "Map not downloadable",
+                "<b>This map was not found in the vault (or is broken).</b>"\
+                "<br/>You need to get it from somewhere else in order to use it.")
         else:
             logger.error("Download Exception", exc_info=sys.exc_info())
-            QtGui.QMessageBox.information(None, "Map installation failed", "<b>This map could not be installed (please report this map or bug).</b>" )
+            QtGui.QMessageBox.information(
+                None,
+                "Map installation failed",
+                "<b>This map could not be installed (please report this map or bug).</b>")
         return False
 
     #Count the map downloads
@@ -587,8 +629,8 @@ def downloadMap(name, silent=False):
         url = VAULT_COUNTER_ROOT + "?map=" + urllib2.quote(link)
         req = urllib2.Request(url, headers={'User-Agent' : "FAF Client"})
         urllib2.urlopen(req)
-        logger.debug("Successfully sent download counter request for: " + url)        
-        
+        logger.debug("Successfully sent download counter request for: " + url)
+
     except:
         logger.warn("Request to map download counter failed for: " + url)
         logger.error("Download Count Exception", exc_info=sys.exc_info())
@@ -596,7 +638,7 @@ def downloadMap(name, silent=False):
     return True
 
 def processMapFolderForUpload(mapDir, positions):
-    """ 
+    """
     Zipping the file and creating thumbnails
     """
     # creating thumbnail
@@ -605,22 +647,24 @@ def processMapFolderForUpload(mapDir, positions):
     if len(files) != 3:
         logger.debug("Insufficient previews for making an archive.")
         return None
-    
+
     #mapName = os.path.basename(mapDir).split(".v")[0]
 
     #making sure we pack only necessary files and not random garbage
     for filename in os.listdir(mapDir):
-        if filename.endswith(".lua") or filename.endswith("preview.jpg") or filename.endswith(".scmap") or filename.endswith(".dds"):
+        endings = ['.lua', 'preview.jpg', '.scmap', '.dds']
+        # stupid trick: False + False == 0, True + False == 1
+        if sum([filename.endswith(x) for x in endings]) > 0:
             files.append(os.path.join(mapDir, filename))
-    
+
     temp = tempfile.NamedTemporaryFile(mode='w+b', suffix=".zip", delete=False)
-    
+
     #creating the zip
     zipped = zipfile.ZipFile(temp, "w", zipfile.ZIP_DEFLATED)
 
     for filename in files:
-        zipped.write(filename, os.path.join(os.path.basename(mapDir),os.path.basename(filename)))
-    
+        zipped.write(filename, os.path.join(os.path.basename(mapDir), os.path.basename(filename)))
+
     temp.flush()
-    
+
     return temp

--- a/src/vault/__init__.py
+++ b/src/vault/__init__.py
@@ -1,7 +1,3 @@
-
-
-
-
 from PyQt4 import QtCore, QtGui
 from PyQt4 import QtWebKit
 from stat import *
@@ -18,6 +14,7 @@ from config import Settings
 
 logger = logging.getLogger(__name__)
 
+
 class FAFPage(QtWebKit.QWebPage):
     def __init__(self):
         super(QtWebKit.QWebPage, self).__init__()
@@ -25,63 +22,71 @@ class FAFPage(QtWebKit.QWebPage):
     def userAgentForUrl(self, url):
         return "FAForever"
 
+
 class MapVault(QtCore.QObject):
     def __init__(self, client, *args, **kwargs):
         QtCore.QObject.__init__(self, *args, **kwargs)
         self.client = client
 
         logger.debug("Map Vault tab instantiating")
-        
+
         self.ui = QtWebKit.QWebView()
 
         self.ui.setPage(FAFPage())
 
-        self.ui.page().mainFrame().javaScriptWindowObjectCleared.connect(self.addScript)
-        
+        self.ui.page().mainFrame().javaScriptWindowObjectCleared. \
+            connect(self.addScript)
+
         self.client.mapsTab.layout().addWidget(self.ui)
 
         self.loaded = False
         self.client.showMaps.connect(self.reloadView)
         self.ui.loadFinished.connect(self.ui.show)
         self.reloadView()
-        
+
     @QtCore.pyqtSlot()
     def reloadView(self):
-        if (self.loaded):
+        if self.loaded:
             return
         self.loaded = True
-        
+
         self.ui.setVisible(False)
 
-        #If a local theme CSS exists, skin the WebView with it
+#       If a local theme CSS exists, skin the WebView with it
         if util.themeurl("vault/style.css"):
-            self.ui.settings().setUserStyleSheetUrl(util.themeurl("vault/style.css"))
+            self.ui.settings().setUserStyleSheetUrl(
+                util.themeurl("vault/style.css"))
 
         ROOT = Settings.get('content/host')
-        self.ui.setUrl(QtCore.QUrl("{route}/faf/vault/maps.php?username={user}&pwdhash={pwdhash}".format(route = Settings.get('content/host'), user = self.client.login, pwdhash = self.client.password)))
+        self.ui.setUrl(
+            QtCore.QUrl("{route}/faf/vault/maps.php?username={user}"
+                        "&pwdhash={pwdhash}".format(
+                            route=Settings.get('content/host'),
+                            user=self.client.login,
+                            pwdhash=self.client.password)))
 
     @QtCore.pyqtSlot()
     def addScript(self):
-        frame  = self.ui.page().mainFrame()
+        frame = self.ui.page().mainFrame()
         frame.addToJavaScriptWindowObject("webVault", self)
-    
+
     def __preparePositions(self, positions, map_size):
         img_size = [256, 256]
         size = [int(map_size['0']), int(map_size['1'])]
         off_x = 0
         off_y = 0
-        
-        if (size[1] > size[0]):
+
+        if size[1] > size[0]:
             img_size[0] = img_size[0]/2
             off_x = img_size[0]/2
-        elif (size[0] > size[1]):
+        elif size[0] > size[1]:
             img_size[1] = img_size[1]/2
             off_y = img_size[1]/2
-            
+
         cf_x = size[0]/img_size[0]
         cf_y = size[1]/img_size[1]
 
-        regexp = re.compile(" \d+\.\d*| \d+")
+        regexp = re.compile(" \\d+\\.\\d*| \\d+")
 
         for postype in positions:
             for pos in positions[postype]:
@@ -90,59 +95,109 @@ class MapVault(QtCore.QObject):
                 y = off_y + float(values[2].strip())/cf_y
                 positions[postype][pos] = [int(x), int(y)]
 
-    @QtCore.pyqtSlot()  
+    @QtCore.pyqtSlot()
     def uploadMap(self):
-        mapDir = QtGui.QFileDialog.getExistingDirectory (self.client, "Select the map directory to upload", maps.getUserMapsFolder(),  QtGui.QFileDialog.ShowDirsOnly)
+        mapDir = QtGui.QFileDialog.getExistingDirectory(
+            self.client,
+            "Select the map directory to upload",
+            maps.getUserMapsFolder(),
+            QtGui.QFileDialog.ShowDirsOnly)
         logger.debug("Uploading map from: " + mapDir)
-        if mapDir != "" :
-            if maps.isMapFolderValid(mapDir) :
+        if mapDir != "":
+            if maps.isMapFolderValid(mapDir):
                 os.chmod(mapDir, S_IWRITE)
                 mapName = os.path.basename(mapDir)
-                zipName = mapName.lower()+".zip" 
-                
-                scenariolua = luaparser.luaParser(os.path.join(mapDir,maps.getScenarioFile(mapDir)))
-                scenarioInfos = scenariolua.parse({'scenarioinfo>name':'name', 'size':'map_size', 'description':'description', 'count:armies':'max_players','map_version':'version','type':'map_type','teams>0>name':'battle_type'}, {'version':'1'})
-                
+                zipName = mapName.lower()+".zip"
+
+                scenariolua = luaparser.luaParser(os.path.join(
+                    mapDir,
+                    maps.getScenarioFile(mapDir)))
+                scenarioInfos = scenariolua.parse({
+                    'scenarioinfo>name':'name', 'size':'map_size',
+                    'description':'description',
+                    'count:armies':'max_players',
+                    'map_version':'version',
+                    'type':'map_type',
+                    'teams>0>name':'battle_type'
+                    }, {'version':'1'})
+
                 if scenariolua.error:
-                    logger.debug("There were " + str(scenariolua.errors) + " errors and " + str(scenariolua.warnings) + " warnings.")
+                    logger.debug("There were {} errors and {} warnings".format(
+                        scenariolua.errors,
+                        scenariolua.warnings
+                        ))
                     logger.debug(scenariolua.errorMsg)
-                    QtGui.QMessageBox.critical(self.client, "Lua parsing error", scenariolua.errorMsg + "\nMap uploading cancelled.")
+                    QtGui.QMessageBox.critical(
+                        self.client,
+                        "Lua parsing error",
+                        "{}\nMap uploading cancelled.".format(
+                            scenariolua.errorMsg))
                 else:
                     if scenariolua.warning:
-                        uploadmap = QtGui.QMessageBox.question(self.client, "Lua parsing warning", scenariolua.errorMsg + "\nDo you want to upload the map?", QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
+                        uploadmap = QtGui.QMessageBox.question(
+                            self.client,
+                            "Lua parsing warning",
+                            "{}\nDo you want to upload the map?".format(
+                                scenariolua.errorMsg),
+                            QtGui.QMessageBox.Yes,
+                            QtGui.QMessageBox.No)
                     else:
                         uploadmap = QtGui.QMessageBox.Yes
                     if uploadmap == QtGui.QMessageBox.Yes:
-                        savelua = luaparser.luaParser(os.path.join(mapDir,maps.getSaveFile(mapDir)))
-                        saveInfos = savelua.parse({'markers>mass*>position':'mass:__parent__', 'markers>hydro*>position':'hydro:__parent__', 'markers>army*>position':'army:__parent__'})
+                        savelua = luaparser.luaParser(os.path.join(
+                            mapDir,
+                            maps.getSaveFile(mapDir)
+                            ))
+                        saveInfos = savelua.parse({
+                            'markers>mass*>position':'mass:__parent__',
+                            'markers>hydro*>position':'hydro:__parent__',
+                            'markers>army*>position':'army:__parent__'})
                         if savelua.error or savelua.warning:
-                           logger.debug("There were " + str(scenariolua.errors) + " errors and " + str(scenariolua.warnings) + " warnings.")
-                           logger.debug(scenariolua.errorMsg)
-                        
-                        self.__preparePositions(saveInfos, scenarioInfos["map_size"])
-                        
-                        tmpFile = maps.processMapFolderForUpload(mapDir, saveInfos)
+                            logger.debug("There were {} errors and {} warnings".format(
+                                scenariolua.errors,
+                                scenariolua.warnings
+                                ))
+                            logger.debug(scenariolua.errorMsg)
+
+                        self.__preparePositions(
+                            saveInfos,
+                            scenarioInfos["map_size"])
+
+                        tmpFile = maps.processMapFolderForUpload(
+                            mapDir,
+                            saveInfos)
                         if not tmpFile:
-                            QtGui.QMessageBox.critical(self.client, "Map uploading error", "Couldn't make previews for " + mapName + "\nMap uploading cancelled.")
+                            QtGui.QMessageBox.critical(
+                                self.client,
+                                "Map uploading error",
+                                "Couldn't make previews for {}\n"
+                                "Map uploading cancelled.".format(mapName))
                             return None
-                        
+
                         qfile = QtCore.QFile(tmpFile.name)
                         self.client.writeToServer("UPLOAD_MAP", zipName, scenarioInfos, qfile)
-                
+
                         #removing temporary files
                         qfile.remove()
-            else :
-                QtGui.QMessageBox.information(self.client,"Map selection",
-                        "This folder doesn't contain valid map data.")
-    
-    @QtCore.pyqtSlot(str)  
+            else:
+                QtGui.QMessageBox.information(
+                    self.client,
+                    "Map selection",
+                    "This folder doesn't contain valid map data.")
+
+    @QtCore.pyqtSlot(str)
     def downloadMap(self, link):
         link = urllib2.unquote(link)
         name = maps.link2name(link)
         if not maps.isMapAvailable(name):
-            maps.downloadMap(name)  
+            maps.downloadMap(name)
             maps.existMaps(True)
         else:
-            show = QtGui.QMessageBox.question(self.client, "Already got the Map", "Seems like you already have that map!<br/><b>Would you like to see it?</b>", QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
+            show = QtGui.QMessageBox.question(
+                self.client,
+                "Already got the Map",
+                "Seems like you already have that map!<br/><b>Would you like to see it?</b>",
+                QtGui.QMessageBox.Yes,
+                QtGui.QMessageBox.No)
             if show == QtGui.QMessageBox.Yes:
                 util.showInExplorer(maps.folderForMap(name))


### PR DESCRIPTION
While investigating #428 I fixed up the codestyle of the maps files a bit. It looks like `maps.py` and `vault/__init.py__` actually don't have anything to do with the bug, so I'm submitting this separately.