### PR TITLE
Make genPrevFromDDS bubble IOError

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * Add new uid implementation (thanks @muellni)
 * Leaderboard display performance improvement (#438, thanks @grotheFAF)
 * Save game logs as default
+* Fix a bug with preview generation (#481)
 
 0.11.60
 =======


### PR DESCRIPTION
genPrevDDS suppressed IOError, leading to wacky logic in consumers.
Changed genPrevDDS to propagate IOError and handled it appropriately in
consumers.

Fixes #475