### PR TITLE
Remove __downloadPreviewFromWeb from maps.preview

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * Fix a bug with preview generation (#481)
 * Remove unused map downloader class (#483)
 * Fix error in PERSONAL_DIR selection (#428)
+* Make map preview download asynchronous (#507)
 
 0.11.60
 =======

--- a/src/coop/_coopwidget.py
+++ b/src/coop/_coopwidget.py
@@ -240,9 +240,9 @@ class CoopWidget(FormClass, BaseClass):
             if uid not in self.games:
                 self.games[uid] = GameItem(uid)
                 self.gameList.addItem(self.games[uid])
-                self.games[uid].update(message, self.client)
+                self.games[uid].update(message)
             else:
-                self.games[uid].update(message, self.client)
+                self.games[uid].update(message)
 
             if message['state'] == "open":
                 # force the display.

--- a/src/fa/maps.py
+++ b/src/fa/maps.py
@@ -430,43 +430,6 @@ def __exportPreviewFromMap(mapname, positions=None):
 
 iconExtensions = ["png"] #, "jpg" removed to have fewer of those costly 404 misses.
 
-
-def __downloadPreviewFromWeb(name):
-    '''
-    Downloads a preview image from the web for the given map name
-    '''
-    # This is done so generated previews always have a lower case name.
-    # This doesn't solve the underlying problem
-    # (case folding Windows vs. Unix vs. FAF)
-    name = name.lower()
-
-    logger.debug("Searching web preview for: " + name)
-
-    for extension in iconExtensions:
-        try:
-            header = urllib2.Request(
-                VAULT_PREVIEW_ROOT + urllib2.quote(name) + "." + extension,
-                headers={'User-Agent' : "FAF Client"})
-            req = urllib2.urlopen(header)
-            img = os.path.join(util.CACHE_DIR, name + "." + extension)
-            with open(img, 'wb') as fp:
-                shutil.copyfileobj(req, fp)
-                fp.flush()
-                os.fsync(fp.fileno())       # probably works fine without the flush and fsync
-                fp.close()
-
-                # Create alpha-mapped preview image
-                im = QtGui.QImage(img) #.scaled(100,100)
-                im.save(img)
-                logger.debug("Web Preview " + extension + " used for: " + name)
-                return img
-        except:
-            logger.error("Web preview download failed for " + name)
-
-    logger.error("Web Preview not found for: " + name)
-    return None
-
-
 def preview(mapname, pixmap=False):
     try:
         # Try to load directly from cache
@@ -482,12 +445,6 @@ def preview(mapname, pixmap=False):
         if img and 'cache' in img and img['cache'] and os.path.isfile(img['cache']):
             logger.debug("Using fresh preview image for: " + mapname)
             return util.icon(img['cache'], False, pixmap)
-        else:
-            # Try to download from web
-            img = __downloadPreviewFromWeb(mapname)
-            if img and os.path.isfile(img):
-                logger.debug("Using web preview image for: " + mapname)
-                return util.icon(img, False, pixmap)
 
         return None
     except:

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -190,12 +190,12 @@ class GamesWidget(FormClass, BaseClass):
         if uid not in self.games:
             self.games[uid] = GameItem(uid)
             self.gameList.addItem(self.games[uid])
-            self.games[uid].update(message, self.client)
+            self.games[uid].update(message)
 
             if message['state'] == 'open' and not message['password_protected']:
                 self.client.notificationSystem.on_event(ns.Notifications.NEW_GAME, message)
         else:
-            self.games[uid].update(message, self.client)
+            self.games[uid].update(message)
 
         # Hide private games
         if self.hideGamesWithPw.isChecked() and message['state'] == 'open' and message['password_protected']:

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -51,7 +51,7 @@ class HostgameWidget(FormClass, BaseClass):
             "state": "open",
         }
 
-        self.game.update(self.message, self.parent.client)
+        self.game.update(self.message)
         self.game.setHidden(False)
         
         i = 0
@@ -93,7 +93,7 @@ class HostgameWidget(FormClass, BaseClass):
         
     def updateText(self, text):
         self.message['title'] = text
-        self.game.update(self.message, self.parent.client)
+        self.game.update(self.message)
         self.game.setHidden(False)
 
     def hosting(self):
@@ -139,7 +139,7 @@ class HostgameWidget(FormClass, BaseClass):
         self.mapname = self.mapList.itemData(index)
 
         self.message['mapname'] = self.mapname
-        self.game.update(self.message, self.parent.client)
+        self.game.update(self.message)
 
     def save_last_hosted_settings(self):
         util.settings.beginGroup("fa.games")


### PR DESCRIPTION
All map preview calls already use the downloadManager class if
maps.preview doesn't find a preview icon. The `__downloadPreviewFromWeb`
call is entirely unnecessary and slows down the client because it is
synchronous.

Fixes #506

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [X] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [x] Rebase onto develop
- [x] Add changelog entry
- [ ] Remove this entire template section
