### PR TITLE
Properly handle non-ascii personal directory path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@
 * Save game logs as default
 * Fix a bug with preview generation (#481)
 * Remove unused map downloader class (#483)
+* Fix error in PERSONAL_DIR selection (#428)
 
 0.11.60
 =======

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -15,6 +15,9 @@ def developer():
 
 from config import VERSION as VERSION_STRING
 
+import logging
+logger = logging.getLogger(__name__)
+
 LOGFILE_MAX_SIZE = 256 * 1024  #256kb should be enough for anyone
 
 UNITS_PREVIEW_ROOT = "{}/faf/unitsDB/icons/big/".format(Settings.get('content/host'))
@@ -90,12 +93,16 @@ if not os.path.exists(PREFSFILENAME):
 DOWNLOADED_RES_PIX = {}
 DOWNLOADING_RES_PIX = {}
 
-PERSONAL_DIR = str(QDesktopServices.storageLocation(QDesktopServices.DocumentsLocation))
+PERSONAL_DIR = unicode(QDesktopServices.storageLocation(QDesktopServices.DocumentsLocation))
+logger.info('PERSONAL_DIR initial: ' + PERSONAL_DIR)
 try:
-    getpass.getuser().decode('ascii')  # Try to see if the user has a wacky username
+    PERSONAL_DIR = PERSONAL_DIR.decode('ascii')
 except:
+    logger.warn('PERSONAL_DIR not ascii')
     PERSONAL_DIR = os.path.join(APPDATA_DIR, "user")
-    
+
+logger.info('PERSONAL_DIR final: ' + PERSONAL_DIR)
+
 #Ensure Application data directories exist
 if not os.path.isdir(APPDATA_DIR):
     os.makedirs(APPDATA_DIR)
@@ -140,9 +147,6 @@ try:
             os.remove(LOG_FILE_FAF)
 except:
     pass
-
-import logging
-logger = logging.getLogger(__name__)
 
 def clearDirectory(directory, confirm=True):
     if (os.path.isdir(directory)):


### PR DESCRIPTION
Existing code only handled non-ascii username. However, localized
windows versions can have non-ascii folder names.

Fixes #428.