### PR TITLE
Use authenticated Github API requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
         } else {
           $headers = @{}
         }
-        (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers  | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
+        (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers $headers  | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
 
 test_script:
   - "%PYTHON%\\python runtests.py -vv --full-trace"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 # GITHUB_TOKEN env var defined in appveyor project
 # GITHUB_USER env var defined in appveyor project
 environment:
+  global:
+    GITHUB_USER: faf-bot
+    GITHUB_TOKEN:
+      secure: Np481CGoJvTGB8O5rZTRswUZagGv7WtWT/TXTABQ184xUbL5vj9NoCtmtNRK6YxF
   matrix:
     - PYTHON: "C:\\Miniconda"
       PYTHON_VERSION: "2.7.11"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 # GITHUB_TOKEN env var defined in appveyor project
+# GITHUB_USER env var defined in appveyor project
 environment:
   matrix:
     - PYTHON: "C:\\Miniconda"
@@ -40,7 +41,7 @@ install:
   - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
   - ps: "$env:PYTEST_QT_API=\"pyqt4v2\""
   - ps: "$env:FAF_FORCE_PRODUCTION=true"
-  - ps: "$env:AUTH_HEADER=\"Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(\"duk3luk3:$($env:GITHUB_TOKEN)\")))\""
+  - ps: "$env:AUTH_HEADER=\"Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(\"$($env:GITHUB_USER):$($env:GITHUB_TOKEN)\")))\""
   # download faf-uid.exe to ./lib/
   - ps: (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers @{"Authorization" = "$env:AUTH_HEADER"} | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,8 +49,10 @@ install:
       |
         if ($env:GITHUB_TOKEN) {
           $env:AUTH_HEADER="Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:GITHUB_USER):$($env:GITHUB_TOKEN)")))"
-          $headers = @{"Authorization" = "$env:AUTH_HEADER"}
+          $headers = @{"Authorization" = "$env:AUTH_HEADER"
+          Write-Host "Added Auth Header"
         } else {
+          Write-Host "No Token, skipping Auth Header. This may lead to build failure due to Github API rate limiting."
           $headers = @{}
         }
         (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers $headers  | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
       |
         if ($env:GITHUB_TOKEN) {
           $env:AUTH_HEADER="Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:GITHUB_USER):$($env:GITHUB_TOKEN)")))"
-          $headers = @{"Authorization" = "$env:AUTH_HEADER"
+          $headers = @{"Authorization" = "$env:AUTH_HEADER"}
           Write-Host "Added Auth Header"
         } else {
           Write-Host "No Token, skipping Auth Header. This may lead to build failure due to Github API rate limiting."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,15 @@ install:
   - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
   - ps: "$env:PYTEST_QT_API=\"pyqt4v2\""
   - ps: "$env:FAF_FORCE_PRODUCTION=true"
-  - ps: "$env:AUTH_HEADER=\"Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(\"$($env:GITHUB_USER):$($env:GITHUB_TOKEN)\")))\""
-  # download faf-uid.exe to ./lib/
-  - ps: (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers @{"Authorization" = "$env:AUTH_HEADER"} | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
+  - ps:
+      |
+        if ($env:GITHUB_TOKEN) {
+          $env:AUTH_HEADER="Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:GITHUB_USER):$($env:GITHUB_TOKEN)")))"
+          $headers = @{"Authorization" = "$env:AUTH_HEADER"}
+        } else {
+          $headers = @{}
+        }
+        (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers  | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
 
 test_script:
   - "%PYTHON%\\python runtests.py -vv --full-trace"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
+# GITHUB_TOKEN env var defined in appveyor project
 environment:
-
   matrix:
     - PYTHON: "C:\\Miniconda"
       PYTHON_VERSION: "2.7.11"
@@ -36,12 +36,13 @@ install:
   - "%PYTHON%\\Scripts\\pip install cffi"
   - "%PYTHON%\\Scripts\\pip install cx_Freeze"
   - "%PYTHON%\\Scripts\\pip install -r requirements.txt --trusted-host content.faforever.com"
+  # get uid.exe
   - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
-  - ps: "get-childitem env:"
   - ps: "$env:PYTEST_QT_API=\"pyqt4v2\""
   - ps: "$env:FAF_FORCE_PRODUCTION=true"
+  - ps: "$env:AUTH_HEADER=\"Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(\"duk3luk3:$($env:GITHUB_TOKEN)\")))\""
   # download faf-uid.exe to ./lib/
-  - ps: (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
+  - ps: (Invoke-WebRequest -Uri https://api.github.com/repos/FAForever/uid/releases/latest -Headers @{"Authorization" = "$env:AUTH_HEADER"} | ConvertFrom-Json).assets | where {$_.name -eq "faf-uid.exe"} | %{ iwr $_.browser_download_url -OutFile ".\\lib\\faf-uid.exe" }
 
 test_script:
   - "%PYTHON%\\python runtests.py -vv --full-trace"


### PR DESCRIPTION
This changes the github api access (for finding latest faf-uid version) in the appveyor build to using authenticated requests.
It uses env vars called `GITHUB_USER` and `GITHUB_TOKEN` that must be filled with a
Github Personal Access Token. 

These vars must be added in Appveyor project settings in "Environment".

OAuth tokens could probably be used instead, but that's more complicated so I didn't look at it.

(This PR won't build successfully until the Build vars are added)