### PR TITLE
feature - replace tab livestream with (old) unitdb

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 * Check for WMI service needed by uid (#523, thanks @muellni)
 * Build improvements (#531)
 * Fix What's New Tab displaying correct page (thanks @downlord)
+* replace Tab Livestreams with (old) Unit Database (#539)
 
 
 0.11.64

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1186</width>
+    <width>983</width>
     <height>697</height>
    </rect>
   </property>
@@ -171,16 +171,16 @@
         </property>
        </layout>
       </widget>
-      <widget class="QWidget" name="livestreamTab">
+      <widget class="QWidget" name="unitdbTab">
        <attribute name="title">
-        <string>Livestreams</string>
+        <string>Units Database</string>
        </attribute>
        <layout class="QGridLayout" name="gridLayout_10">
         <property name="margin">
          <number>0</number>
         </property>
         <item row="0" column="0">
-         <widget class="QWebView" name="LivestreamWebView">
+         <widget class="QWebView" name="unitdbWebView">
           <property name="url">
            <url>
             <string>about:blank</string>
@@ -246,8 +246,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1186</width>
-     <height>21</height>
+     <width>983</width>
+     <height>18</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuOptions">

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -301,7 +301,7 @@ class ClientWindow(FormClass, BaseClass):
         self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.vaultsTab), util.icon("client/mods.png"))
         self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.ladderTab), util.icon("client/ladder.png"))
         self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.tourneyTab), util.icon("client/tourney.png"))
-        self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.livestreamTab), util.icon("client/twitch.png"))
+        self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.unitdbTab), util.icon("client/twitch.png"))
         self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.replaysTab), util.icon("client/replays.png"))
         self.mainTabs.setTabIcon(self.mainTabs.indexOf(self.tutorialsTab), util.icon("client/tutorials.png"))
 
@@ -519,8 +519,11 @@ class ClientWindow(FormClass, BaseClass):
         # warning setup
         self.warning = QtGui.QHBoxLayout()
 
-        # live streams
-        self.LivestreamWebView.setUrl(QtCore.QUrl("http://www.faforever.com/livestream"))
+        # units database (ex. live streams)
+        # old unitDB
+        self.unitdbWebView.setUrl(QtCore.QUrl("http://direct.faforever.com/faf/unitsDB"))
+        # spookys unitDB (will be moved to site)
+        # self.unitdbWebView.setUrl(QtCore.QUrl("http://spooky.github.io/unitdb/#/"))
 
         self.warnPlayer = QtGui.QLabel(self)
         self.warnPlayer.setText(


### PR DESCRIPTION
with the new website the Livestreams-tab has a 404 - issue #534 
replacing it with a unitdb seems like a usefull reuse.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- ~[ ] Final commit includes "Fixes #issue" in commit message~

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [x] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
