### PR TITLE
Make __main__.py a runnable-anywhere executable scipt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - "%PYTHON%\\Scripts\\pip install cffi"
   - "%PYTHON%\\Scripts\\pip install cx_Freeze"
   - "%PYTHON%\\Scripts\\pip install -r requirements.txt --trusted-host content.faforever.com"
-  - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py .) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
+  - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py .\\res) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
   - ps: "get-childitem env:"
   - ps: "$env:PYTEST_QT_API=\"pyqt4v2\""
   - ps: "$env:FAF_FORCE_PRODUCTION=true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - "%PYTHON%\\Scripts\\pip install cffi"
   - "%PYTHON%\\Scripts\\pip install cx_Freeze"
   - "%PYTHON%\\Scripts\\pip install -r requirements.txt --trusted-host content.faforever.com"
-  - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
+  - ps: "$env:APPVEYOR_BUILD_VERSION = (& C:\\Miniconda\\python .\\src\\config\\version.py .) + \"+\" + $env:APPVEYOR_BUILD_NUMBER"
   - ps: "get-childitem env:"
   - ps: "$env:PYTEST_QT_API=\"pyqt4v2\""
   - ps: "$env:FAF_FORCE_PRODUCTION=true"

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 * Build improvements (#531)
 * Fix What's New Tab displaying correct page (thanks @downlord)
 * replace Tab Livestreams with (old) Unit Database (#539)
+* Add logging to game updater and disable cert verification on test server (#558)
 
 
 0.11.64

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * replace Tab Livestreams with (old) Unit Database (#539)
 * Add logging to game updater and disable cert verification on test server (#558)
 * Clean up 'res' directory finding (#552)
+* Improve ladder race selection (#554)
 
 0.11.64
 =======

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@
 * Fix What's New Tab displaying correct page (thanks @downlord)
 * replace Tab Livestreams with (old) Unit Database (#539)
 * Add logging to game updater and disable cert verification on test server (#558)
-
+* Clean up 'res' directory finding (#552)
 
 0.11.64
 =======

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,11 @@ if sys.platform == 'win32':
     import PyQt4.uic
 
     root_dir = os.path.dirname(os.path.abspath(__file__))
+    res_dir = os.path.join(root_dir, "res")
     git_version = version.get_git_version()
     msi_version = version.msi_version(git_version)
     appveyor_build_version = os.getenv('APPVEYOR_BUILD_VERSION')
-    version.write_version_file(appveyor_build_version, root_dir)
+    version.write_version_file(appveyor_build_version, res_dir)
 
     print('Git version:', git_version,
           'Release version:', appveyor_build_version,
@@ -48,7 +49,6 @@ except OSError:
 # Dependencies are automatically detected, but it might need fine tuning.
 build_exe_options = {
     'include_files': ['res',
-                      'RELEASE-VERSION',
                       'imageformats',
                       'libeay32.dll',
                       'ssleay32.dll',

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,12 @@ product_name = 'Forged Alliance Forever'
 if sys.platform == 'win32':
     import config.version as version
     import PyQt4.uic
+
+    root_dir = os.path.dirname(os.path.abspath(__file__))
     git_version = version.get_git_version()
     msi_version = version.msi_version(git_version)
     appveyor_build_version = os.getenv('APPVEYOR_BUILD_VERSION')
-    version.write_release_version(appveyor_build_version)
+    version.write_version_file(appveyor_build_version, root_dir)
 
     print('Git version:', git_version,
           'Release version:', appveyor_build_version,

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -26,20 +26,7 @@ from PyQt4 import QtGui, uic
 path = os.path.join(os.path.dirname(sys.argv[0]), "PyQt4.uic.widget-plugins")
 uic.widgetPluginPath.append(path)
 
-# Are we running from a frozen interpreter?
-if getattr(sys, 'frozen', False):
-    os.chdir(os.path.dirname(sys.executable))
-else:
-    if sys.platform == 'win32':
-        # We are most likely running from source
-        srcDir = os.path.dirname(os.path.relpath(__file__))
-        devRoot = os.path.abspath(os.path.join(srcDir, os.pardir))
-        os.chdir(devRoot)
-        # We need to set the working directory correctly.
-
 import util
-if sys.platform == 'win32':
-    util.COMMON_DIR = os.path.join(os.getcwd(), "res")
 
 # Set up crash reporting
 excepthook_original = sys.excepthook

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 """
 Created on Dec 1, 2011
 
@@ -15,6 +16,24 @@ sip.setapi('QProcess', 2)
 
 import os
 import sys
+
+# Some linux distros (like Gentoo) make package scripts available
+# by copying and modifying them. This breaks path to our modules.
+# This hack restores our path, but really the best way to fix it
+# would be to convert our imports to relative form.
+# We check if we can import our packages already in case we are run
+# through the interpreter (e.g. from source).
+
+import imp
+if __package__ is None and not hasattr(sys, 'frozen'):
+    try:
+        imp.find_module("client")
+    except ImportError:
+        # __main__ executed directly
+        import os.path
+        import fafclient
+        path = os.path.realpath(os.path.abspath(fafclient.__file__))
+        sys.path.insert(0, os.path.dirname(path))
 
 if os.path.isdir("lib"):
     sys.path.insert(0, os.path.abspath("lib"))

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -3,6 +3,7 @@ import os
 import sys
 import logging
 import trueskill
+import fafpath
 from PyQt4 import QtCore
 from logging.handlers import RotatingFileHandler, MemoryHandler
 
@@ -118,8 +119,7 @@ def make_dirs():
                 set_data_path_permissions()
                 os.makedirs(path)
 
-VERSION = version.get_git_version()
-
+VERSION = version.get_release_version(os.path.dirname(fafpath.get_resdir()))
 
 def is_development_version():
     return version.is_development_version(VERSION)
@@ -172,4 +172,4 @@ if environment == 'development':
     logging.getLogger().addHandler(devh)
     logging.getLogger().setLevel(logging.INFO)
 
-logging.getLogger().info("FAF version: {} Environment: {}".format(version.get_git_version(), environment))
+logging.getLogger().info("FAF version: {} Environment: {}".format(VERSION, environment))

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -119,7 +119,7 @@ def make_dirs():
                 set_data_path_permissions()
                 os.makedirs(path)
 
-VERSION = version.get_release_version(os.path.dirname(fafpath.get_resdir()))
+VERSION = version.get_release_version(fafpath.get_resdir())
 
 def is_development_version():
     return version.is_development_version(VERSION)

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -170,6 +170,6 @@ if environment == 'development':
     devh = logging.StreamHandler()
     devh.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)-30s %(message)s'))
     logging.getLogger().addHandler(devh)
-    logging.getLogger().setLevel(logging.INFO)
+    logging.getLogger().setLevel(Settings.get('client/logs/level', type=int))
 
 logging.getLogger().info("FAF version: {} Environment: {}".format(VERSION, environment))

--- a/src/config/develop.py
+++ b/src/config/develop.py
@@ -11,3 +11,8 @@ else:
 
 defaults = production_defaults.copy()
 defaults['host'] = 'test.faforever.com'
+
+# FIXME: Temporary fix for broken https config on test server
+# Turns off certificate verification entirely
+import ssl
+ssl._https_verify_certificates(False)

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -194,6 +194,7 @@ class Updater(QtCore.QObject):
 
     def fetchFile(self, url, toFile):
         try:
+            logger.info('Updater: Downloading {}'.format(url))
             progress = QtGui.QProgressDialog()
             progress.setCancelButtonText("Cancel")
             progress.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint)

--- a/src/fafpath.py
+++ b/src/fafpath.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+__all__ = ["get_resdir"]
+
+# default unix res path
+UNIX_SHARE_PATH = '/usr/share/faforever'
+
+def run_from_frozen():
+    return getattr(sys, 'frozen', False)
+
+def run_from_unix_install():
+    local_res = os.path.join(os.getcwd(), "res")
+    return not run_from_frozen() and sys.platform != 'win32' and not os.path.exists(local_res)
+
+def get_resdir():
+    if run_from_frozen():
+        # On Windows the res dir is relative to the executable or main.py script
+        return os.path.join(os.path.dirname(sys.executable), "res")
+    elif run_from_unix_install():
+        return UNIX_SHARE_PATH
+    else:
+        # We are most likely running from source
+        srcDir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(os.path.dirname(srcDir), "res")

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -25,11 +25,8 @@ LOGFILE_MAX_SIZE = 256 * 1024  #256kb should be enough for anyone
 
 UNITS_PREVIEW_ROOT = "{}/faf/unitsDB/icons/big/".format(Settings.get('content/host'))
 
-# On Windows the res dir is relative to the executable or main.py script
-COMMON_DIR = os.path.join(os.getcwd(), "res")
-if sys.platform != 'win32' and not os.path.exists(COMMON_DIR):
-    #On Linux the res dir is installed as /usr/share/fafclient
-    COMMON_DIR = os.path.join("/usr", "share", "fafclient")
+import fafpath
+COMMON_DIR = fafpath.get_resdir()
 
 # These directories are in Appdata (e.g. C:\ProgramData on some Win7 versions)
 if 'ALLUSERSPROFILE' in os.environ:


### PR DESCRIPTION
This closes #550 and makes installation of FAF on linux distros
much easier - now you can just copy over __main__ to $PATH rather
than make brittle scripts with hardcoded path to site-packages.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
