### PR TITLE
Disable HTTPS Certificate verification on test server

### DIFF
--- a/src/config/develop.py
+++ b/src/config/develop.py
@@ -11,3 +11,8 @@ else:
 
 defaults = production_defaults.copy()
 defaults['host'] = 'test.faforever.com'
+
+# FIXME: Temporary fix for broken https config on test server
+# Turns off certificate verification entirely
+import ssl
+ssl._https_verify_certificates(False)

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -194,6 +194,7 @@ class Updater(QtCore.QObject):
 
     def fetchFile(self, url, toFile):
         try:
+            logger.info('Updater: Downloading {}'.format(url))
             progress = QtGui.QProgressDialog()
             progress.setCancelButtonText("Cancel")
             progress.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint)


### PR DESCRIPTION
Because the test server doesn't have a valid certificate for `content.test.faforever.com`, the game updater (and other things) don't work.

This PR disables HTTPS verification when in the "development" environment.

It also adds logging to the updater.

Initial PR:

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [X] Rebase onto develop
- [x] Add changelog entry
- [ ] Remove this entire template section
