### PR TITLE
Handle case when user is not logged in in Players

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * Clean up 'res' directory finding (#552)
 * Improve ladder race selection (#554)
 * Make selected mods persistent (#560)
+* Disable modvault feedback (#568)
 
 0.11.64
 =======

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 * Improve ladder race selection (#554)
 * Make selected mods persistent (#560)
 * Disable modvault feedback (#568)
+* Fix local replays being shown as broken when offline (#564)
 
 0.11.64
 =======

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 * Add logging to game updater and disable cert verification on test server (#558)
 * Clean up 'res' directory finding (#552)
 * Improve ladder race selection (#554)
+* Make selected mods persistent (#560)
 
 0.11.64
 =======

--- a/src/client/players.py
+++ b/src/client/players.py
@@ -18,6 +18,7 @@ class Players:
     """
     def __init__(self, me):
         self.me = me
+        "Logged in player. Can be None if we're not connected."
         self.coloredNicknames = False
 
         # UID -> Player map
@@ -63,6 +64,10 @@ class Players:
         '''
         Returns a user's color depending on their status with relation to the FAF client
         '''
+        # Return default color if we're not logged in
+        if self.me is None:
+            return self.getColor("default")
+
         if id == self.me.id:
             return self.getColor("self")
         if id in self.friends:

--- a/src/fa/maps.py
+++ b/src/fa/maps.py
@@ -436,7 +436,7 @@ def preview(mapname, pixmap=False):
         for extension in iconExtensions:
             img = os.path.join(util.CACHE_DIR, mapname + "." + extension)
             if os.path.isfile(img):
-                logger.debug("Using cached preview image for: " + mapname)
+                logger.log(5,"Using cached preview image for: " + mapname)
                 return util.icon(img, False, pixmap)
 
         # Try to find in local map folder

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -77,7 +77,7 @@ class HostgameWidget(FormClass, BaseClass):
             self.mods[mod.totalname] = mod
             self.modList.addItem(mod.totalname)
 
-        names = [mod.totalname for mod in modvault.getActiveMods(uimods=False)]
+        names = [mod.totalname for mod in modvault.getActiveMods(uimods=False, temporary=False)]
         logger.debug("Active Mods detected: %s" % str(names))
         for name in names:
             l = self.modList.findItems(name, QtCore.Qt.MatchExactly)
@@ -122,7 +122,7 @@ class HostgameWidget(FormClass, BaseClass):
 
         modnames = [str(moditem.text()) for moditem in self.modList.selectedItems()]
         mods = [self.mods[modstr] for modstr in modnames]
-        modvault.setActiveMods(mods, True)
+        modvault.setActiveMods(mods, True, False)
 
         self.parent.client.host_game(title=self.title,
                                  mod=self.featured_mod,

--- a/src/modvault/modwidget.py
+++ b/src/modvault/modwidget.py
@@ -34,24 +34,32 @@ class ModWidget(FormClass, BaseClass):
         else:
             self.Picture.setPixmap(mod.thumbnail.pixmap(100,100))
 
-        self.Comments.setItemDelegate(CommentItemDelegate(self))
-        self.BugReports.setItemDelegate(CommentItemDelegate(self))
+        #self.Comments.setItemDelegate(CommentItemDelegate(self))
+        #self.BugReports.setItemDelegate(CommentItemDelegate(self))
+
+        self.tabWidget.setEnabled(False)
 
         if self.mod.uid in self.parent.uids:
             self.DownloadButton.setText("Remove Mod")
         self.DownloadButton.clicked.connect(self.download)
-        self.likeButton.clicked.connect(self.like)
-        self.LineComment.returnPressed.connect(self.addComment)
-        self.LineBugReport.returnPressed.connect(self.addBugReport)
 
-        for item in mod.comments:
-            comment = CommentItem(self,item["uid"])
-            comment.update(item)
-            self.Comments.addItem(comment)
-        for item in mod.bugreports:
-            comment = CommentItem(self,item["uid"])
-            comment.update(item)
-            self.BugReports.addItem(comment)
+        #self.likeButton.clicked.connect(self.like)
+        #self.LineComment.returnPressed.connect(self.addComment)
+        #self.LineBugReport.returnPressed.connect(self.addBugReport)
+
+        #for item in mod.comments:
+        #    comment = CommentItem(self,item["uid"])
+        #    comment.update(item)
+        #    self.Comments.addItem(comment)
+        #for item in mod.bugreports:
+        #    comment = CommentItem(self,item["uid"])
+        #    comment.update(item)
+        #    self.BugReports.addItem(comment)
+
+        self.likeButton.setEnabled(False)
+        self.LineComment.setEnabled(False)
+        self.LineBugReport.setEnabled(False)
+
         
     @QtCore.pyqtSlot()
     def download(self):

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -427,7 +427,7 @@ def iconUnit(unitname):
 
     img = os.path.join(CACHE_DIR, unitname)
     if os.path.isfile(img):
-        logger.debug("Using cached preview image for: " + unitname)
+        logger.log(5, "Using cached preview image for: " + unitname)
         return icon(img, False)
     # Try to download from web
     img = __downloadPreviewFromWeb(unitname)


### PR DESCRIPTION
Players class handles mapping of various IDs to players and their
relations to the logged in player ('me'). If we're not logged in, 'me'
stays null. We should account for that.

This fixes #564.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>