### PR TITLE
Disable Modvault feedback

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 * Clean up 'res' directory finding (#552)
 * Improve ladder race selection (#554)
 * Make selected mods persistent (#560)
+* Disable modvault feedback (#568)
 
 0.11.64
 =======

--- a/src/modvault/modwidget.py
+++ b/src/modvault/modwidget.py
@@ -34,24 +34,32 @@ class ModWidget(FormClass, BaseClass):
         else:
             self.Picture.setPixmap(mod.thumbnail.pixmap(100,100))
 
-        self.Comments.setItemDelegate(CommentItemDelegate(self))
-        self.BugReports.setItemDelegate(CommentItemDelegate(self))
+        #self.Comments.setItemDelegate(CommentItemDelegate(self))
+        #self.BugReports.setItemDelegate(CommentItemDelegate(self))
+
+        self.tabWidget.setEnabled(False)
 
         if self.mod.uid in self.parent.uids:
             self.DownloadButton.setText("Remove Mod")
         self.DownloadButton.clicked.connect(self.download)
-        self.likeButton.clicked.connect(self.like)
-        self.LineComment.returnPressed.connect(self.addComment)
-        self.LineBugReport.returnPressed.connect(self.addBugReport)
 
-        for item in mod.comments:
-            comment = CommentItem(self,item["uid"])
-            comment.update(item)
-            self.Comments.addItem(comment)
-        for item in mod.bugreports:
-            comment = CommentItem(self,item["uid"])
-            comment.update(item)
-            self.BugReports.addItem(comment)
+        #self.likeButton.clicked.connect(self.like)
+        #self.LineComment.returnPressed.connect(self.addComment)
+        #self.LineBugReport.returnPressed.connect(self.addBugReport)
+
+        #for item in mod.comments:
+        #    comment = CommentItem(self,item["uid"])
+        #    comment.update(item)
+        #    self.Comments.addItem(comment)
+        #for item in mod.bugreports:
+        #    comment = CommentItem(self,item["uid"])
+        #    comment.update(item)
+        #    self.BugReports.addItem(comment)
+
+        self.likeButton.setEnabled(False)
+        self.LineComment.setEnabled(False)
+        self.LineBugReport.setEnabled(False)
+
         
     @QtCore.pyqtSlot()
     def download(self):


### PR DESCRIPTION
Disables linking / commenting / bugreporting on mods.

This is a temporary measure because the new server doesn't support the
requests the client sends for that functionality.
In the long term, these features will use the API.

Fixes #559

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [X] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [X] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
