### PR TITLE
Make the Reload Stylesheet Menu Item reload all Stylesheets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,11 +11,13 @@
 * Fix typo preventing rehost feature from working (#630 / #632)
 * Remove needless abstract base class for client (#629)
 * Fall back to APPDATA if Documents folder cannot be created (#619, #626)
+* Make all (themed) stylesheets reloadable (#584)
 
 Contributors:
   - Duke
   - speed2
   - Wesmania
+  - yorick
 
 0.12.2
 ======

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -374,6 +374,7 @@
      <property name="title">
       <string>&amp;Theme...</string>
      </property>
+	 <addaction name="actionReloadStyleSheet"/>	 
     </widget>
     <widget class="QMenu" name="menuClear">
      <property name="title">
@@ -630,6 +631,11 @@
    <property name="text">
     <string>&amp;Save game logs</string>
    </property>
+  </action>
+  <action name="actionReloadStyleSheet">
+	<property name="text">
+	 <string> Reload Stylesheet </string>
+	</property>
   </action>
   <action name="actionColoredNicknames">
    <property name="checkable">

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -2,7 +2,7 @@ from functools import partial
 
 from PyQt4 import Qt
 from PyQt4.QtCore import QUrl
-from PyQt4.QtGui import QLabel, QStyle
+from PyQt4.QtGui import QLabel, QStyle, QAction
 from PyQt4.QtNetwork import QAbstractSocket
 
 import config
@@ -208,7 +208,7 @@ class ClientWindow(FormClass, BaseClass):
 
         # create user interface (main window) and load theme
         self.setupUi(self)
-        self.setStyleSheet(util.readstylesheet("client/client.css"))
+        util.setStyleSheet(self, "client/client.css")
 
         self.setWindowTitle("FA Forever " + util.VERSION_STRING)
 
@@ -717,24 +717,23 @@ class ClientWindow(FormClass, BaseClass):
         self.actionSetLiveReplays.triggered.connect(self.updateOptions)
         self.actionSaveGamelogs.toggled.connect(self.on_actionSavegamelogs_toggled)
         self.actionSaveGamelogs.setChecked(self.gamelogs)
+        self.actionReloadStyleSheet.triggered.connect(util.reloadStyleSheets)
         self.actionColoredNicknames.triggered.connect(self.updateOptions)
         self.actionFriendsOnTop.triggered.connect(self.updateOptions)
 
         # Init themes as actions.
         themes = util.listThemes()
         for theme in themes:
-            action = self.menuTheme.addAction(str(theme))
+            action = QAction(str(theme), self.menuTheme)
             action.triggered.connect(self.switchTheme)
             action.theme = theme
             action.setCheckable(True)
 
             if util.getTheme() == theme:
                 action.setChecked(True)
+            self.menuTheme.insertAction(self.actionReloadStyleSheet, action)
+        self.menuTheme.insertSeparator(self.actionReloadStyleSheet)
 
-        # Nice helper for the developers
-        self.menuTheme.addSeparator()
-        self.menuTheme.addAction("Reload Stylesheet",
-                                 lambda: self.setStyleSheet(util.readstylesheet("client/client.css")))
 
     @QtCore.pyqtSlot()
     def updateOptions(self):

--- a/src/coop/_coopwidget.py
+++ b/src/coop/_coopwidget.py
@@ -61,12 +61,11 @@ class CoopWidget(FormClass, BaseClass):
         
         self.linkButton.clicked.connect(self.linkVanilla)
         self.leaderBoard.setVisible(0)
-        self.stylesheet              = util.readstylesheet("coop/formatters/style.css")
         self.FORMATTER_LADDER        = unicode(util.readfile("coop/formatters/ladder.qthtml"))
         self.FORMATTER_LADDER_HEADER = unicode(util.readfile("coop/formatters/ladder_header.qthtml"))
 
-        self.leaderBoard.setStyleSheet(self.stylesheet)
-        
+        util.setStyleSheet(self.leaderBoard, "coop/formatters/style.css")
+
         self.leaderBoardTextGeneral.anchorClicked.connect(self.openUrl)
         self.leaderBoardTextOne.anchorClicked.connect(self.openUrl)
         self.leaderBoardTextTwo.anchorClicked.connect(self.openUrl)
@@ -108,7 +107,7 @@ class CoopWidget(FormClass, BaseClass):
 
                         
         doc = QtGui.QTextDocument()
-        doc.addResource(3, QtCore.QUrl("style.css"), self.stylesheet )
+        doc.addResource(3, QtCore.QUrl("style.css"), self.leaderBoard.styleSheet() )
         html = ("<html><head><link rel='stylesheet' type='text/css' href='style.css'></head><body>")
         
         if self.selectedItem:

--- a/src/stats/_statswidget.py
+++ b/src/stats/_statswidget.py
@@ -52,9 +52,8 @@ class StatsWidget(BaseClass, FormClass):
         
         self.FORMATTER_LADDER        = unicode(util.readfile("stats/formatters/ladder.qthtml"))
         self.FORMATTER_LADDER_HEADER = unicode(util.readfile("stats/formatters/ladder_header.qthtml"))
-        self.stylesheet = util.readstylesheet("stats/formatters/style.css")
 
-        self.leagues.setStyleSheet(self.stylesheet)
+        util.setStyleSheet(self.leagues, "stats/formatters/style.css")
     
         # setup other tabs
         self.mapstat = mapstat.LadderMapStat(self.client, self)

--- a/src/tourneys/_tournamentswidget.py
+++ b/src/tourneys/_tournamentswidget.py
@@ -34,7 +34,7 @@ class TournamentsWidget(FormClass, BaseClass):
         self.tourneysTab = {}
 
         #Special stylesheet       
-        self.setStyleSheet(util.readstylesheet("tournaments/formatters/style.css"))
+        util.setStyleSheet(self, "tournaments/formatters/style.css")
 
         self.updateTimer = QtCore.QTimer(self)
         self.updateTimer.timeout.connect(self.updateTournaments)

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -28,6 +28,8 @@ UNITS_PREVIEW_ROOT = "{}/faf/unitsDB/icons/big/".format(Settings.get('content/ho
 import fafpath
 COMMON_DIR = fafpath.get_resdir()
 
+stylesheets = {} # map [qt obj] ->  filename of stylesheet
+
 # These directories are in Appdata (e.g. C:\ProgramData on some Win7 versions)
 if 'ALLUSERSPROFILE' in os.environ:
     APPDATA_DIR = os.path.join(os.environ['ALLUSERSPROFILE'], "FAForever")
@@ -358,6 +360,15 @@ def readlines(filename, themed=True):
     result.close()
     return lines
 
+
+def setStyleSheet(obj, filename):
+    stylesheets[obj] = filename
+    obj.setStyleSheet(readstylesheet(filename))
+
+
+def reloadStyleSheets():
+    for obj, filename in stylesheets.iteritems():
+        obj.setStyleSheet(readstylesheet(filename))
 
 def readstylesheet(filename):
     if __themedir and os.path.isfile(os.path.join(__themedir, filename)):


### PR DESCRIPTION
Makes the Reload Stylesheet Menu Item reload all Stylesheets. 
The Qt Objects that get a nondefault stylesheet are being remembered by encapsulating setStyleSheet.

Fixes #584

Initial PR:

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [x] Rebase onto develop
- [x] Add changelog entry
- [ ] Remove this entire template section
