### PR TITLE
Fix/update movies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Check for updates on Github (#578)
 * fix usability of 'Live Games' in Replays (#615)
 * Fix live replay sorting (#616)
+* Unpack movies from mod packages (#610)
 
 Contributors:
  - Duke

--- a/src/fa/check.py
+++ b/src/fa/check.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import glob
+import shutil
 
 from PyQt4 import QtGui
 
@@ -63,6 +66,32 @@ def path(parent):
 def game(parent):
     return True
 
+def checkMovies():
+    """
+    This function rescues movies (.sdf files) from the gamedata folder and copies
+    them to the movies folder.
+
+    This is a hack needed because the game updater can only handle bin and gamedata.
+    """
+
+    # construct dirs
+    gd = os.path.join(util.APPDATA_DIR, 'gamedata')
+    mv = os.path.join(util.APPDATA_DIR, 'movies')
+
+    # make sure moviedir exists
+    if not os.path.exists(mv):
+        try:
+            os.makedirs(mv)
+        except:
+            logger.exception('Failed to make moviedir! Check permissions.')
+            return
+
+    moviefiles = glob.glob(os.path.join(gd, '*.sdf'))
+    for gdf in moviefiles:
+        bn = os.path.basename(mvf)
+        mvf = os.path.join(mv, bn)
+        if not os.file.exists(gdf) or os.stat(gdf).st_size != os.stat(mvg).st_size:
+            shutil.copyfile(gdf, mvf)
 
 def check(featured_mod, mapname=None, version=None, modVersions=None, sim_mods=None, silent=False):
     """

--- a/src/fa/check.py
+++ b/src/fa/check.py
@@ -75,7 +75,7 @@ def check(featured_mod, mapname=None, version=None, modVersions=None, sim_mods=N
     if version is None:
         logger.info("Version unknown, assuming latest")
 
-    # Perform the actual comparisons and updating                    
+    # Perform the actual comparisons and updating
     logger.info("Updating FA for mod: " + str(featured_mod) + ", version " + str(version))
 
     import client

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -122,6 +122,7 @@ class Updater(QtCore.QObject):
         QtCore.QObject.__init__(self, *args, **kwargs)
 
         self.filesToUpdate = []
+        self.updatedFiles = []
 
         self.lastData = time.time()
 
@@ -553,6 +554,7 @@ class Updater(QtCore.QObject):
             toFile = os.path.join(util.APPDATA_DIR, str(path), str(fileToCopy))
             self.fetchFile(url, toFile)
             self.filesToUpdate.remove(str(fileToCopy))
+            self.updatedFiles.append(str(fileToCopy))
 
         elif action == "SEND_FILE":
             path = stream.readQString()
@@ -577,6 +579,7 @@ class Updater(QtCore.QObject):
 
             log("%s is copied in %s." % (fileToCopy, path))
             self.filesToUpdate.remove(str(fileToCopy))
+            self.updatedFiles.append(str(fileToCopy))
 
         elif action == "SEND_PATCH_URL":
             destination = str(stream.readQString())
@@ -592,6 +595,7 @@ class Updater(QtCore.QObject):
 
                 log("%s/%s is patched." % (destination, fileToUpdate))
                 self.filesToUpdate.remove(str(fileToUpdate))
+                self.updatedFiles.append(str(fileToUpdate))
             else :
                 log("Failed to update file :'(")
         else:


### PR DESCRIPTION
The game updater can only update bin and gamedata folders.
This adds a hack that rescues movie files (`*.sdf`) from the gamedata
folder and copies them to the movies folder.

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
