### PR TITLE
fix usability of 'Live Games' in Replays #614

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 
 * Make sure client updater progress is shown (#605)
 * Check for updates on Github (#578)
+* fix usability of 'Live Games' in Replays (#614)
 
 Contributors:
  - Duke

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -411,7 +411,10 @@ class ReplaysWidget(BaseClass, FormClass):
                 
                 if time.time() - info.get('launched_at', time.time()) < LIVEREPLAY_DELAY_TIME:
                     item.setHidden(True)
-                    QtCore.QTimer.singleShot(LIVEREPLAY_DELAY_QTIMER, self.displayReplay)  # The delay is there because we have a delay in the livereplay server
+                    # to get the delay right on client start, subtract the already passed game time
+                    delay_time = LIVEREPLAY_DELAY_QTIMER - int(1000*(time.time() - info.get('launched_at', time.time())))
+                    QtCore.QTimer.singleShot(delay_time, self.displayReplay)
+                    # The delay is there because we have a delay in the livereplay server
 
             # For debugging purposes, format our tooltip for the top level items
             # so it contains a human-readable representation of the info dictionary
@@ -428,11 +431,17 @@ class ReplaysWidget(BaseClass, FormClass):
                 self.client.downloader.downloadMap(item.info['mapname'], item, True)
                 icon = util.icon("games/unknown_map.png")
 
-            item.setText(0, time.strftime("%H:%M", time.localtime(item.info.get('launched_at', time.time()))))
+            item.setText(0, time.strftime("%Y-%m-%d  -  %H:%M", time.localtime(item.info.get('launched_at', time.time()))))
             item.setTextColor(0, QtGui.QColor(client.instance.getColor("default")))
                                     
-            item.setIcon(0, icon)
-            item.setText(1, info['title'])
+            if info['featured_mod'] == "coop":  # no map icons for coop
+                item.setIcon(0, util.icon("games/unknown_map.png"))
+            else:
+                item.setIcon(0, icon)
+            if info['featured_mod'] == "ladder1v1":
+                item.setText(1, info['title'])
+            else:
+                item.setText(1, info['title'] + "    -    [host: " + info['host'] + "]")
             item.setTextColor(1, QtGui.QColor(client.instance.getColor("player")))
             
             item.setText(2, info['featured_mod'])


### PR DESCRIPTION
add full date to info to show fresh games on top - fix #614
assign unknown_map to coop games
add host info to game title
fix displayReplay delay on Client start

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
