### PR TITLE
Fix live replay sorting

### DIFF
--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -25,6 +25,20 @@ from replays.replayitem import ReplayItem, ReplayItemDelegate
 
 FormClass, BaseClass = util.loadUiType("replays/replays.ui")
 
+class LiveReplayItem(QtGui.QTreeWidgetItem):
+    def __init__(self, time):
+        QtGui.QTreeWidgetItem.__init__(self)
+        self.time = time
+
+    def __lt__(self, other):
+        return self.time < other.time
+    def __le__(self, other):
+        return self.time <= other.time
+    def __gt__(self, other):
+        return self.time > other.time
+    def __ge__(self, other):
+        return self.time >= other.time
+
 
 class ReplaysWidget(BaseClass, FormClass):
     SOCKET = 11002
@@ -404,7 +418,7 @@ class ReplaysWidget(BaseClass, FormClass):
                 item.takeChildren()  # Clear the children of this item before we're updating it
             else:
                 # Creating a fresh item
-                item = QtGui.QTreeWidgetItem()
+                item = LiveReplayItem(info.get('launched_at', time.time()))
                 self.games[info['uid']] = item
                 
                 self.liveTree.insertTopLevelItem(0, item)


### PR DESCRIPTION
Until now live replays were implicitly sorted by the first column,
time. Now their widgets are subclassed and sorted by their start
time timestamp, so sorting is independent from column contents and
doesn't break after midnight.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [x] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
