### PR TITLE
Fix updater displaying update dialog twice

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Fix live replay sorting (#616)
 * Unpack movies from mod packages (#610)
 * Render "what's new" directly in client from WP-API (#533, #603)
+* Fix updater displaying update dialog twice (#612)
 
 Contributors:
  - Duke


### PR DESCRIPTION
Client updater now waits both on github update checker results and on
the response from server whether the client is outdated before displaying
the update popup.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
