### PR TITLE
[WIP] Disable notifications when game running

### DIFF
--- a/res/notification_system/ns_settings.ui
+++ b/res/notification_system/ns_settings.ui
@@ -26,7 +26,21 @@
       <number>2</number>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-      <item row="2" column="1">
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="nsEnabled">
+        <property name="text">
+         <string>Enable Notification System</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>PopUp Lifetime (in seconds)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
        <widget class="QComboBox" name="nsPositionComboBox">
         <item>
          <property name="text">
@@ -50,7 +64,7 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QSpinBox" name="nsPopLifetime">
         <property name="maximum">
          <number>999</number>
@@ -60,24 +74,36 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>PopUp Position</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>PopUp Lifetime (in seconds)</string>
-        </property>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="nsIngameComboBox">
+        <item>
+         <property name="text">
+          <string>Enable</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Disable</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Queue</string>
+         </property>
+        </item>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="nsEnabled">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Enable Notification System</string>
+         <string>When Ingame</string>
         </property>
        </widget>
       </item>

--- a/src/notifications/__init__.py
+++ b/src/notifications/__init__.py
@@ -21,12 +21,23 @@ class Notifications:
         self.dialog = NotificationDialog(self.client,self.settings)
         self.events = []
         self.disabledStartup = True
+        self.game_running = False
         self.lock = Lock()
+
+
+        client.gameEnter.connect(self.gameEnter)
+        client.gameExit.connect(self.gameExit)
 
         self.user = util.icon("client/user.png", pix=True)
 
+    def gameEnter(self):
+        self.game_running = True
+
+    def gameExit(self):
+        self.game_running = False
+
     def isDisabled(self):
-        return self.disabledStartup or not self.settings.enabled
+        return self.disabledStartup or self.game_running or not self.settings.enabled
 
     def setNotificationEnabled(self, enabled):
         self.settings.enabled = enabled

--- a/src/notifications/ns_dialog.py
+++ b/src/notifications/ns_dialog.py
@@ -54,7 +54,7 @@ class NotificationDialog(FormClass, BaseClass):
     @QtCore.pyqtSlot()
     def hide(self):
         super(FormClass, self).hide()
-        self.client.notificationSystem.dialogClosed()
+        self.client.notificationSystem.nextEvent()
 
     # mouseReleaseEvent sometimes not fired
     def mousePressEvent(self, event):

--- a/src/notifications/ns_dialog.py
+++ b/src/notifications/ns_dialog.py
@@ -54,7 +54,8 @@ class NotificationDialog(FormClass, BaseClass):
     @QtCore.pyqtSlot()
     def hide(self):
         super(FormClass, self).hide()
-        self.client.notificationSystem.nextEvent()
+        # check for next event to show notification for
+        self.client.notificationSystem.checkEvent()
 
     # mouseReleaseEvent sometimes not fired
     def mousePressEvent(self, event):

--- a/src/notifications/ns_settings.py
+++ b/src/notifications/ns_settings.py
@@ -11,6 +11,11 @@ The UI of the Notification System Settings Frame.
 Each module/hook for the notification system must be registered here.
 """
 
+class IngameNotification(Enum):
+    ENABLE = 0
+    DISABLE = 1
+    QUEUE = 2
+
 class NotificationPosition(Enum):
     BOTTOM_RIGHT = 0
     TOP_RIGHT = 1
@@ -61,16 +66,19 @@ class NsSettingsDialog(FormClass2, BaseClass2):
         self.enabled = Settings.get('notifications/enabled', True, type=bool)
         self.popup_lifetime = Settings.get('notifications/popup_lifetime', 5, type=int)
         self.popup_position = NotificationPosition(Settings.get('notifications/popup_position', NotificationPosition.BOTTOM_RIGHT.value, type=int))
+        self.ingame_notifications =  IngameNotification(Settings.get('notifications/ingame', IngameNotification.ENABLE, type=int))
 
         self.nsEnabled.setChecked(self.enabled)
         self.nsPopLifetime.setValue(self.popup_lifetime)
         self.nsPositionComboBox.setCurrentIndex(self.popup_position.value)
+        self.nsIngameComboBox.setCurrentIndex(self.ingame_notifications.value)
 
 
     def saveSettings(self):
         Settings.set('notifications/enabled', self.enabled)
         Settings.set('notifications/popup_lifetime', self.popup_lifetime)
         Settings.set('notifications/popup_position', self.popup_position.value)
+        Settings.set('notifications/ingame', self.ingame_notifications.value)
 
         self.client.actionNsEnabled.setChecked(self.enabled)
 
@@ -79,6 +87,7 @@ class NsSettingsDialog(FormClass2, BaseClass2):
         self.enabled = self.nsEnabled.isChecked()
         self.popup_lifetime = self.nsPopLifetime.value()
         self.popup_position = NotificationPosition(self.nsPositionComboBox.currentIndex())
+        self.ingame_notifications = IngameNotification(self.nsIngameComboBox.currentIndex())
 
         self.saveSettings()
         self.hide()


### PR DESCRIPTION
Notifications while playing are bad for people using full-screen and probably generally unwanted by most players.

This PR extends the notification settings dialog to add an option for notifications while ingame, allowing to choose between enable/disable/queue notifications.

Fixes #627 