### PR TITLE
Don't log null byte in replayserver.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Fix irc/notification recursion loop (#638, 641)
 * Fix movie file crc calculations (#640, #642)
 * Make Github updater see prereleases (#643, #645)
+* Fix null byte being logged by replay code (#648, #649)
 
 Contributors:
   - Duke

--- a/src/fa/replayserver.py
+++ b/src/fa/replayserver.py
@@ -74,7 +74,7 @@ class ReplayRecorder(QtCore.QObject):
             #This prefix means "P"osting replay in the livereplay protocol of FA, this needs to be stripped from the local file            
             if data.startsWith("P/"):
                 rest = data.indexOf("\x00") + 1
-                self.__logger.info("Stripping prefix '" + str(data.left(rest)) + "' from replay.")
+                self.__logger.info("Stripping prefix '" + str(data.left(rest - 1)) + "' from replay.")
                 self.replayData.append(data.right(data.size() - rest))
             else:
                 self.replayData.append(data)


### PR DESCRIPTION
Fixes #648.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
