### PR TITLE
Show online Clanmember over normal Chatters

### DIFF
--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -25,9 +25,10 @@ class Chatter(QtGui.QTableWidgetItem):
 
     RANK_ELEVATION = 0
     RANK_FRIEND = 1
-    RANK_USER = 2
-    RANK_NONPLAYER = 3
-    RANK_FOE = 4
+    RANK_CLAN = 2
+    RANK_USER = 3
+    RANK_NONPLAYER = 4
+    RANK_FOE = 5
 
     def __init__(self, parent, user, lobby, *args, **kwargs):
         QtGui.QTableWidgetItem.__init__(self, *args, **kwargs)
@@ -91,11 +92,11 @@ class Chatter(QtGui.QTableWidgetItem):
 
     def __lt__(self, other):
         """ Comparison operator used for item list sorting """
-        firstStatus = self.getUserRank(self)
-        secondStatus = self.getUserRank(other)
-
         if self.name == self.lobby.client.login: return True
         if other.name == self.lobby.client.login: return False
+
+        firstStatus = self.getUserRank(self)
+        secondStatus = self.getUserRank(other)
 
         # if not same rank sort
         if firstStatus != secondStatus:
@@ -113,6 +114,8 @@ class Chatter(QtGui.QTableWidgetItem):
             return self.RANK_FRIEND - (2 if self.lobby.client.friendsontop else 0)
         if self.lobby.client.players.isFoe(other_chatter.id):
             return self.RANK_FOE
+        if self.lobby.client.me.clan and self.lobby.client.me.clan == other_chatter.clan:
+            return self.RANK_CLAN
         if self.lobby.client.players.isPlayer(other_chatter.id):
             return self.RANK_USER
 


### PR DESCRIPTION
Implements #622 
Basicaly shows Clanmembers after yourself, friends and mods, but before normal users and IRC users in any IRC channel.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
