### PR TITLE
Make util get its APPDATA_DIR from Settings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 =====
 
 * Significantly refactor connection to lobby server (#620, #621)
+* Remove redundant APPDATA_DIR loading in util (#665, #666)
 
 Contributors:
   - Wesmania

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -32,11 +32,7 @@ COMMON_DIR = fafpath.get_resdir()
 
 stylesheets = {} # map [qt obj] ->  filename of stylesheet
 
-# These directories are in Appdata (e.g. C:\ProgramData on some Win7 versions)
-if 'ALLUSERSPROFILE' in os.environ:
-    APPDATA_DIR = os.path.join(os.environ['ALLUSERSPROFILE'], "FAForever")
-else:
-    APPDATA_DIR = os.path.join(os.environ['HOME'], "FAForever")
+APPDATA_DIR = Settings.get('client/data_path')
 
 #This is used to store init_*.lua files
 LUA_DIR = os.path.join(APPDATA_DIR, "lua")


### PR DESCRIPTION
Instead of setting it independently in copypasta code.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
