### PR TITLE
Fix promoted ThemeMenu breaking themes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 * Significantly refactor connection to lobby server (#620, #621)
 * Remove redundant APPDATA_DIR loading in util (#665, #666)
+* Fix theme breakage caused by a promoted widget (#669, #670)
 
 Contributors:
   - Wesmania

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -367,7 +367,7 @@
      <addaction name="actionSetGamePort"/>
      <addaction name="actionSaveGamelogs"/>
     </widget>
-    <widget class="ThemeMenu" name="menuTheme">
+    <widget class="QMenu" name="menuTheme">
      <property name="tearOffEnabled">
       <bool>false</bool>
      </property>
@@ -694,11 +694,6 @@
    <class>QWebView</class>
    <extends>QWidget</extends>
    <header>QtWebKitWidgets/QWebView</header>
-  </customwidget>
-  <customwidget>
-   <class>ThemeMenu</class>
-   <extends>QMenu</extends>
-   <header location="global">client.theme_menu</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -14,6 +14,7 @@ from client.players import Players
 from client.connection import LobbyInfo, ServerConnection, \
         Dispatcher, ConnectionState, ServerReconnecter
 from client.updater import ClientUpdater, GithubUpdateChecker
+from client.theme_menu import ThemeMenu
 import fa
 from connectivity.helper import ConnectivityHelper
 from fa import GameSession
@@ -743,8 +744,9 @@ class ClientWindow(FormClass, BaseClass):
         self.actionColoredNicknames.triggered.connect(self.updateOptions)
         self.actionFriendsOnTop.triggered.connect(self.updateOptions)
 
-        self.menuTheme.setup(util.listThemes())
-        self.menuTheme.themeSelected.connect(lambda theme: util.setTheme(theme, True))
+        self._menuThemeHandler = ThemeMenu(self.menuTheme)
+        self._menuThemeHandler.setup(util.listThemes())
+        self._menuThemeHandler.themeSelected.connect(lambda theme: util.setTheme(theme, True))
 
     @QtCore.pyqtSlot()
     def updateOptions(self):

--- a/src/client/theme_menu.py
+++ b/src/client/theme_menu.py
@@ -1,23 +1,24 @@
 from PyQt4 import QtGui, QtCore
 import util
 
-class ThemeMenu(QtGui.QMenu):
+class ThemeMenu(QtCore.QObject):
     themeSelected = QtCore.pyqtSignal(object)
 
-    def __init__(self, parent):
-        QtGui.QMenu.__init__(self, parent)
+    def __init__(self, menu):
+        QtCore.QObject.__init__(self)
+        self._menu = menu
         self._themes = {}
         # Hack to not process check signals when we're changing them ourselves
         self._updating = False
 
     def setup(self, themes):
         for theme in themes:
-            action = self.addAction(str(theme))
+            action = self._menu.addAction(str(theme))
             action.toggled.connect(self.handle_toggle)
             self._themes[action] = theme
             action.setCheckable(True)
-        self.addSeparator()
-        self.addAction("Reload Stylesheet", util.reloadStyleSheets)
+        self._menu.addSeparator()
+        self._menu.addAction("Reload Stylesheet", util.reloadStyleSheets)
 
         self._updateThemeChecks()
 
@@ -34,7 +35,9 @@ class ThemeMenu(QtGui.QMenu):
 
         action = self.sender()
         if not toggled:
+            self._updating = True
             action.setChecked(True)
+            self._updating = False
         else:
             self.themeSelected.emit(self._themes[action])
             self._updateThemeChecks()


### PR DESCRIPTION
Turns out promoting widgets is not a good idea when other themes touch
.ui files. Let's avoid it in the future.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
