### PR TITLE
Switch secondary server to new dispatcher object

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -201,7 +201,7 @@ class ClientWindow(FormClass, BaseClass):
         self.connectivity = None  # type: ConnectivityHelper
 
         # stat server
-        self.statsServer = secondaryServer.SecondaryServer("Statistic", 11002, self)
+        self.statsServer = secondaryServer.SecondaryServer("Statistic", 11002, self.lobby_dispatch)
 
         # create user interface (main window) and load theme
         self.setupUi(self)

--- a/src/secondaryServer/secondaryserver.py
+++ b/src/secondaryServer/secondaryserver.py
@@ -38,7 +38,7 @@ class SecondaryServer(QtCore.QObject):
     RESULT_BUSY = 4         # Server is currently busy
     RESULT_PASS = 5         # User refuses to update by canceling
     
-    def __init__(self, name, socket, requester, *args, **kwargs):
+    def __init__(self, name, socket, dispatcher, *args, **kwargs):
         """
         Constructor
         """
@@ -51,7 +51,7 @@ class SecondaryServer(QtCore.QObject):
         self.logger = logger
         
         self.socketPort = socket
-        self.requester = requester
+        self.dispatcher = dispatcher
 
         self.command = None
         self.message = None
@@ -141,10 +141,8 @@ class SecondaryServer(QtCore.QObject):
         A fairly pythonic way to process received strings as JSON messages.
         """
         message = json.loads(data_string)
-        cmd = "handle_" + message['command']
-        logger.debug("answering from server :" + str(cmd))
-        if hasattr(self.requester, cmd):
-            getattr(self.requester, cmd)(message)
+        logger.debug("answering from server :" + str(message["command"]))
+        self.dispatcher.dispatch(message)
 
     @QtCore.pyqtSlot('QAbstractSocket::SocketError')
     def handleServerError(self, socketError):


### PR DESCRIPTION
The connection refactor added a dispatcher object, but missed the fact
that SecondaryServer also used the getattr method. Pass the dispatcher
to the secondary server and use it to dispatch messages.

Fixes #683.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
