### PR TITLE
add more sorting options to hosted games in Play

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Fix theme breakage caused by a promoted widget (#669, #670)
 * Fix random/nomads faction shown in replay info (#676)
 * Fix lobby name change not showing in Play (#690) 
+* Add sorting games after Map and Host to Play (#686)
 
 Contributors:
   - Wesmania

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -79,7 +79,7 @@ class GamesWidget(FormClass, BaseClass):
         self.gameList.itemDoubleClicked.connect(self.gameDoubleClicked)
         self.gameList.sortBy = self.sort_games_index  # Default Sorting is By Players count
 
-        self.sortGamesComboBox.addItems(['By Players', 'By Game Quality', 'By avg. Player Rating'])
+        self.sortGamesComboBox.addItems(['By Players', 'By avg. Player Rating', 'By Map', 'By Host', 'By Age'])
         self.sortGamesComboBox.currentIndexChanged.connect(self.sortGamesComboChanged)
         self.sortGamesComboBox.setCurrentIndex(self.sort_games_index)
 

--- a/src/games/gameitem.py
+++ b/src/games/gameitem.py
@@ -381,8 +381,10 @@ class GameItem(QtGui.QListWidgetItem):
 
         # Sort Games
         # 0: By Player Count
-        # 1: By Game Quality
-        # 2: By avg. Player Rating
+        # 1: By avg. Player Rating
+        # 2: By Map
+        # 3: By Host
+        # 4+: By age = uid
         try:
             sortby = self.listWidget().sortBy
         except AttributeError:
@@ -390,9 +392,11 @@ class GameItem(QtGui.QListWidgetItem):
         if sortby == 0:
             return len(self.players) > len(other.players)
         elif sortby == 1:
-            return self.gamequality > other.gamequality
-        elif sortby == 2:
             return self.average_rating > other.average_rating
+        elif sortby == 2:
+            return self.mapdisplayname.lower() < other.mapdisplayname.lower()
+        elif sortby == 3:
+            return self.host.lower() < other.host.lower()
         else:
             # Default: by UID.
             return self.uid < other.uid

--- a/src/games/gameitem.py
+++ b/src/games/gameitem.py
@@ -78,9 +78,9 @@ class GameItem(QtGui.QListWidgetItem):
 
         self.uid            = uid
         self.mapname        = None
-        self.mapdisplayname = None
+        self.mapdisplayname = ""
         self.title          = None
-        self.host           = None
+        self.host           = ""
         self.hostid         = -1
         self.teams          = []
         self.password_protected = False
@@ -171,7 +171,7 @@ class GameItem(QtGui.QListWidgetItem):
 
         self.title = message['title']  # can be renamed in Lobby (now)
 
-        if self.host is None:  # new game
+        if self.host == "":  # new game
             self.host = message['host']
             self.password_protected = message.get('password_protected', False)
             self.mod = message['featured_mod']


### PR DESCRIPTION
add: By Map, By Host, By Age
these options have increasingly less sorting movement of the hosted games 
a possible fix #685

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
