### PR TITLE
fix lobby name change not showing in Play

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Remove redundant APPDATA_DIR loading in util (#665, #666)
 * Fix theme breakage caused by a promoted widget (#669, #670)
 * Fix random/nomads faction shown in replay info (#676)
+* Fix lobby name change not showing in Play (#690) 
 
 Contributors:
   - Wesmania

--- a/src/games/gameitem.py
+++ b/src/games/gameitem.py
@@ -169,8 +169,9 @@ class GameItem(QtGui.QListWidgetItem):
             logger.error('gamesitem.update called with 3 args')
             logger.error(traceback.format_stack())
 
-        if self.title is None:  # you can't change this...
-            self.title = message['title']
+        self.title = message['title']  # can be renamed in Lobby (now)
+
+        if self.host is None:  # new game
             self.host = message['host']
             self.password_protected = message.get('password_protected', False)
             self.mod = message['featured_mod']


### PR DESCRIPTION
new Lobby option to rename game title, wasn't reflected in gameitem update
fixes server/issues/#274

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
