### PR TITLE
Fix usage of ClientWindow.send in avatar widget

### DIFF
--- a/src/chat/_avatarWidget.py
+++ b/src/chat/_avatarWidget.py
@@ -39,7 +39,7 @@ class playerAvatar(QtGui.QDialog):
     def removeThem(self):
         for user in self.checkBox :
             if self.checkBox[user].checkState() == 2:
-                self.parent.send(dict(command="admin", action="remove_avatar", iduser=user, idavatar=self.idavatar))
+                self.parent.lobby_connection.send(dict(command="admin", action="remove_avatar", iduser=user, idavatar=self.idavatar))
         self.close()
             
     def createUserSelection(self):
@@ -117,7 +117,7 @@ class avatarWidget(QtGui.QDialog):
                     fileDatas = base64.b64encode(zlib.compress(file.readAll()))
                     file.close()
                 
-                    self.parent.send(dict(command="avatar", action="upload_avatar", name=os.path.basename(fileName),
+                    self.parent.lobby_connection.send(dict(command="avatar", action="upload_avatar", name=os.path.basename(fileName),
                                           description=text, file=fileDatas))
                     
             else:
@@ -143,14 +143,14 @@ class avatarWidget(QtGui.QDialog):
     
     def doit(self, val):
         if self.personal:
-            self.parent.send(dict(command="avatar", action="select", avatar=val))
+            self.parent.lobby_connection.send(dict(command="avatar", action="select", avatar=val))
             self.close()
  
         else:
             if self.user is None:
-                self.parent.send(dict(command="admin", action="list_avatar_users", avatar=val))
+                self.parent.lobby_connection.send(dict(command="admin", action="list_avatar_users", avatar=val))
             else:
-                self.parent.send(dict(command="admin", action="add_avatar", user=self.user, avatar=val))
+                self.parent.lobby_connection.send(dict(command="admin", action="add_avatar", user=self.user, avatar=val))
                 self.close()
                 
     def doPlayerAvatarList(self, message):


### PR DESCRIPTION
Switch it over to lobby_connection.send. Grepping for '.+\.send' suggests
this was the last place that was using ClientWidow.send.

Fixes #692.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
