### PR TITLE
698 refactor replays widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 * Cleanup receiving game info (#708, #709)
 * Add Friend/Foe feature for IRC users (#609, #657)
 * Replace game quality in the play tab (NOT in the lobby) by average rating (#687, #688)
+* Split replay widget to separate classes (#698, #699)
 
 Contributors:
  - Wesmania

--- a/src/coop/_coopwidget.py
+++ b/src/coop/_coopwidget.py
@@ -268,7 +268,7 @@ class CoopWidget(FormClass, BaseClass, BusyWidget):
         if not fa.instance.available():
             return
 
-        game = [g for g in self.games.iteritems() if self.games[g].widget is item]
+        game = [g for g in self.games.keys() if self.games[g].widget is item]
         if not game:
             return
         game = game[0]

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -338,7 +338,7 @@ class GamesWidget(FormClass, BaseClass):
         if not fa.check.game(self.client):
             return
 
-        game = [g for g in self.games.iteritems() if self.games[g].widget is item]
+        game = [g for g in self.games.keys() if self.games[g].widget is item]
         if not game:
             return
         game = game[0]

--- a/src/replays/connection.py
+++ b/src/replays/connection.py
@@ -1,0 +1,104 @@
+from PyQt5 import QtCore, QtNetwork
+import json
+
+import logging
+logger = logging.getLogger(__name__)
+
+# Connection to the replay vault. Given how this works, it will one day
+# be replaced with FAF API.
+
+class ReplaysConnection(QtCore.QObject):
+    def __init__(self, dispatch, host, port):
+        QtCore.QObject.__init__(self)
+
+        self.dispatch = dispatch
+        self.blockSize = 0
+        self.host = host
+        self.port = port
+
+        self.replayVaultSocket = QtNetwork.QTcpSocket()
+        self.replayVaultSocket.readyRead.connect(self._readDataFromServer)
+        self.replayVaultSocket.error.connect(self._handleServerError)
+        self.replayVaultSocket.disconnected.connect(self._disconnected)
+
+    def connect(self):
+        """ connect to the replay vault server """
+        state = self.replayVaultSocket.state()
+        states = QtNetwork.QAbstractSocket
+        if state != states.ConnectedState and state != states.ConnectingState:
+            self.replayVaultSocket.connectToHost(self.host, self.port)
+
+    def receiveJSON(self, data_string, stream):
+        """ A fairly pythonic way to process received strings as JSON messages. """
+
+        try:
+            message = json.loads(data_string)
+            self.dispatch.dispatch(message)
+        except ValueError as e:
+            logger.error("Error decoding json ")
+            logger.error(e)
+        self.replayVaultSocket.disconnectFromHost()
+
+    @QtCore.pyqtSlot()
+    def _readDataFromServer(self):
+        ins = QtCore.QDataStream(self.replayVaultSocket)
+        ins.setVersion(QtCore.QDataStream.Qt_4_2)
+
+        while not ins.atEnd():
+            if self.blockSize == 0:
+                if self.replayVaultSocket.bytesAvailable() < 4:
+                    return
+                self.blockSize = ins.readUInt32()
+            if self.replayVaultSocket.bytesAvailable() < self.blockSize:
+                return
+
+            action = ins.readQString()
+            logger.debug("Replay Vault Server: " + action)
+            self.receiveJSON(action, ins)
+            self.blockSize = 0
+
+    def send(self, message):
+        data = json.dumps(message)
+        logger.debug("Outgoing JSON Message: " + data)
+        self._writeToServer(data)
+
+    def _writeToServer(self, action, *args, **kw):
+        logger.debug(("writeToServer(" + action + ", [" + ', '.join(args) + "])"))
+
+        block = QtCore.QByteArray()
+        out = QtCore.QDataStream(block, QtCore.QIODevice.ReadWrite)
+        out.setVersion(QtCore.QDataStream.Qt_4_2)
+        out.writeUInt32(0)
+        out.writeQString(action)
+
+        for arg in args:
+            if type(arg) is int:
+                out.writeInt(arg)
+            elif isinstance(arg, str):
+                out.writeQString(arg)
+            elif type(arg) is float:
+                out.writeFloat(arg)
+            elif type(arg) is list:
+                out.writeQVariantList(arg)
+            else:
+                logger.warn("Uninterpreted Data Type: " + str(type(arg)) + " of value: " + str(arg))
+                out.writeQString(str(arg))
+
+        out.device().seek(0)
+        out.writeUInt32(block.size() - 4)
+        self.replayVaultSocket.write(block)
+
+    def _handleServerError(self, socketError):
+        if socketError == QtNetwork.QAbstractSocket.RemoteHostClosedError:
+            logger.info("Replay Server down: The server is down for maintenance, please try later.")
+
+        elif socketError == QtNetwork.QAbstractSocket.HostNotFoundError:
+            logger.info("Connection to Host lost. Please check the host name and port settings.")
+
+        elif socketError == QtNetwork.QAbstractSocket.ConnectionRefusedError:
+            logger.info("The connection was refused by the peer.")
+        else:
+            logger.info("The following error occurred: %s." % self.replayVaultSocket.errorString())
+
+    def _disconnected(self):
+        logger.debug("Disconnected from server")


### PR DESCRIPTION
Split the ReplaysWidget to 4 different classes handling the 3 tabs and connection to the replay vault server, making the code vastly more readable. Special care is taken in order to not modify the layout files (and potentially break themes).

Fixes #698.

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
