### PR TITLE
fix for user in chat userlist shown in long gone games

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 * Clean up layout of login widget (#652, #653)
 * Use "foo" instead of user password in develop mode (#712, #653)
 * Remove unused label from GamesWidget (#717)
+* Fix for user in chat shown in long gone games (#705) 
 
 Contributors:
   - Wesmania

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -1,7 +1,7 @@
 from PyQt4 import QtCore, QtNetwork
 
 import logging
-import config
+import time
 import fa
 import json
 import sys
@@ -370,9 +370,11 @@ class LobbyInfo(QtCore.QObject):
         self.modInfo.emit(message)
 
     def handle_game_info(self, message):
-        if 'games' in message:
+        if 'games' in message:  # initial bunch of games from server after client start
             for game in message['games']:
-                self.gameInfo.emit(game)
+                # ignore zombie games (>12 hours) (until server fix)
+                if not (game['state'] == 'playing' and time.time() - game['launched_at'] > 12 * 3600):
+                    self.gameInfo.emit(game)
         else:
             self.gameInfo.emit(message)
 


### PR DESCRIPTION
filter zombie games in client connection.py handle_game_info
workaround for #704 

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
