### PR TITLE
remove unused label [subset]RankHint from gameswidget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 * Fix crash on opening files in explorer on non-Windows (#654, #655)
 * Clean up layout of login widget (#652, #653)
 * Use "foo" instead of user password in develop mode (#712, #653)
+* Remove unused label from GamesWidget (#717)
 
 Contributors:
   - Wesmania

--- a/res/client/client.css
+++ b/res/client/client.css
@@ -434,7 +434,7 @@ QLabel#labelSortGames,#labelJoinGame,#labelHostGame,#labelAutomatch,#labelMyRepl
     color:white;
 }
 
-QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelSubsetRankedHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
+QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
 {
     color:#AAAAAA;
 }

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -1,658 +1,635 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>Form</class>
-  <widget class="QWidget" name="Form">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>996</width>
-        <height>679</height>
-      </rect>
-    </property>
-    <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>996</width>
+    <height>679</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
       </sizepolicy>
-    </property>
-    <property name="windowTitle">
-      <string>Form</string>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-        <widget class="QFrame" name="frame">
-          <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelAutomatch">
+        <property name="palette">
+         <palette>
+          <active/>
+          <inactive/>
+          <disabled/>
+         </palette>
+        </property>
+        <property name="font">
+         <font>
+          <family>Segoe UI</family>
+          <pointsize>12</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>1 vs 1 Automatch</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelRankedHint">
+        <property name="mouseTracking">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;p, li { white-space: pre-wrap; }&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a few of your favorite factions and hit play to get matched against a player of your level in a random map! Choose all or no faction for random.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="rankedFrame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>60</height>
+         </size>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <property name="margin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item row="3" column="0">
+          <widget class="QProgressBar" name="searchProgress">
+           <property name="font">
+            <font>
+             <pointsize>4</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Scanning for Opponents</string>
+           </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>0</number>
+           </property>
+           <property name="value">
+            <number>0</number>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="format">
+            <string>scanning</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>5</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QToolButton" name="rankedUEF">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>UEF Ranked Match</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>UEF</string>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonIconOnly</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::NoArrow</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="rankedCybran">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Cybran Ranked Match</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Cybran</string>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonIconOnly</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::NoArrow</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="rankedAeon">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Aeon Ranked Match</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Aeon</string>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonIconOnly</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::NoArrow</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="rankedSeraphim">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
+             <property name="toolTip">
+              <string>Seraphim Ranked Match</string>
+             </property>
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Seraphim</string>
+             </property>
+             <property name="iconSize">
+              <size>
+               <width>50</width>
+               <height>50</height>
+              </size>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonIconOnly</enum>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::NoArrow</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0">
+          <widget class="QToolButton" name="rankedPlay">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
             </sizepolicy>
-          </property>
-          <property name="lineWidth">
-            <number>0</number>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-            <property name="margin">
-              <number>0</number>
-            </property>
-            <item>
-              <widget class="QLabel" name="labelAutomatch">
-                <property name="palette">
-                  <palette>
-                    <active/>
-                    <inactive/>
-                    <disabled/>
-                  </palette>
-                </property>
-                <property name="font">
-                  <font>
-                    <family>Segoe UI</family>
-                    <pointsize>12</pointsize>
-                    <weight>75</weight>
-                    <bold>true</bold>
-                  </font>
-                </property>
-                <property name="text">
-                  <string>1 vs 1 Automatch</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QLabel" name="labelRankedHint">
-                <property name="palette">
-                  <palette>
-                    <active/>
-                    <inactive/>
-                    <disabled/>
-                  </palette>
-                </property>
-                <property name="mouseTracking">
-                  <bool>true</bool>
-                </property>
-                <property name="text">
-                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;p, li { white-space: pre-wrap; }&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select your favorite faction and get matched against a player of your level in a random map! Choose all or no faction for random.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="alignment">
-                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                </property>
-                <property name="wordWrap">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QLabel" name="labelSubsetRankedHint">
-                <property name="mouseTracking">
-                  <bool>true</bool>
-                </property>
-                <property name="text">
-                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;p, li { white-space: pre-wrap; }&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Select a few of your favorite factions and hit play to get matched against a player of your level in a random map! Choose all or no faction for random.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="wordWrap">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QFrame" name="rankedFrame">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                  <size>
-                    <width>50</width>
-                    <height>60</height>
-                  </size>
-                </property>
-                <property name="frameShape">
-                  <enum>QFrame::StyledPanel</enum>
-                </property>
-                <property name="frameShadow">
-                  <enum>QFrame::Plain</enum>
-                </property>
-                <layout class="QGridLayout" name="gridLayout">
-                  <property name="margin">
-                    <number>0</number>
-                  </property>
-                  <property name="spacing">
-                    <number>0</number>
-                  </property>
-                  <item row="3" column="0">
-                    <widget class="QProgressBar" name="searchProgress">
-                      <property name="font">
-                        <font>
-                          <pointsize>4</pointsize>
-                        </font>
-                      </property>
-                      <property name="toolTip">
-                        <string>Scanning for Opponents</string>
-                      </property>
-                      <property name="minimum">
-                        <number>0</number>
-                      </property>
-                      <property name="maximum">
-                        <number>0</number>
-                      </property>
-                      <property name="value">
-                        <number>0</number>
-                      </property>
-                      <property name="alignment">
-                        <set>Qt::AlignCenter</set>
-                      </property>
-                      <property name="format">
-                        <string>scanning</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item row="4" column="0">
-                    <spacer name="verticalSpacer">
-                      <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                      </property>
-                      <property name="sizeType">
-                        <enum>QSizePolicy::Minimum</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                        <size>
-                          <width>5</width>
-                          <height>5</height>
-                        </size>
-                      </property>
-                    </spacer>
-                  </item>
-                  <item row="0" column="0">
-                    <layout class="QHBoxLayout" name="horizontalLayout_2">
-                      <property name="spacing">
-                        <number>0</number>
-                      </property>
-                      <item>
-                        <widget class="QToolButton" name="rankedUEF">
-                          <property name="sizePolicy">
-                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                            </sizepolicy>
-                          </property>
-                          <property name="minimumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="maximumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="focusPolicy">
-                            <enum>Qt::NoFocus</enum>
-                          </property>
-                          <property name="toolTip">
-                            <string>UEF Ranked Match</string>
-                          </property>
-                          <property name="autoFillBackground">
-                            <bool>false</bool>
-                          </property>
-                          <property name="text">
-                            <string>UEF</string>
-                          </property>
-                          <property name="iconSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="checkable">
-                            <bool>true</bool>
-                          </property>
-                          <property name="toolButtonStyle">
-                            <enum>Qt::ToolButtonIconOnly</enum>
-                          </property>
-                          <property name="autoRaise">
-                            <bool>true</bool>
-                          </property>
-                          <property name="arrowType">
-                            <enum>Qt::NoArrow</enum>
-                          </property>
-                        </widget>
-                      </item>
-                      <item>
-                        <widget class="QToolButton" name="rankedCybran">
-                          <property name="sizePolicy">
-                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                            </sizepolicy>
-                          </property>
-                          <property name="minimumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="maximumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="focusPolicy">
-                            <enum>Qt::NoFocus</enum>
-                          </property>
-                          <property name="toolTip">
-                            <string>Cybran Ranked Match</string>
-                          </property>
-                          <property name="autoFillBackground">
-                            <bool>false</bool>
-                          </property>
-                          <property name="text">
-                            <string>Cybran</string>
-                          </property>
-                          <property name="iconSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="checkable">
-                            <bool>true</bool>
-                          </property>
-                          <property name="toolButtonStyle">
-                            <enum>Qt::ToolButtonIconOnly</enum>
-                          </property>
-                          <property name="autoRaise">
-                            <bool>true</bool>
-                          </property>
-                          <property name="arrowType">
-                            <enum>Qt::NoArrow</enum>
-                          </property>
-                        </widget>
-                      </item>
-                      <item>
-                        <widget class="QToolButton" name="rankedAeon">
-                          <property name="sizePolicy">
-                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                            </sizepolicy>
-                          </property>
-                          <property name="minimumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="maximumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="focusPolicy">
-                            <enum>Qt::NoFocus</enum>
-                          </property>
-                          <property name="toolTip">
-                            <string>Aeon Ranked Match</string>
-                          </property>
-                          <property name="autoFillBackground">
-                            <bool>false</bool>
-                          </property>
-                          <property name="text">
-                            <string>Aeon</string>
-                          </property>
-                          <property name="iconSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="checkable">
-                            <bool>true</bool>
-                          </property>
-                          <property name="toolButtonStyle">
-                            <enum>Qt::ToolButtonIconOnly</enum>
-                          </property>
-                          <property name="autoRaise">
-                            <bool>true</bool>
-                          </property>
-                          <property name="arrowType">
-                            <enum>Qt::NoArrow</enum>
-                          </property>
-                        </widget>
-                      </item>
-                      <item>
-                        <widget class="QToolButton" name="rankedSeraphim">
-                          <property name="sizePolicy">
-                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                              <horstretch>0</horstretch>
-                              <verstretch>0</verstretch>
-                            </sizepolicy>
-                          </property>
-                          <property name="minimumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="maximumSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="focusPolicy">
-                            <enum>Qt::NoFocus</enum>
-                          </property>
-                          <property name="toolTip">
-                            <string>Seraphim Ranked Match</string>
-                          </property>
-                          <property name="autoFillBackground">
-                            <bool>false</bool>
-                          </property>
-                          <property name="text">
-                            <string>Seraphim</string>
-                          </property>
-                          <property name="iconSize">
-                            <size>
-                              <width>50</width>
-                              <height>50</height>
-                            </size>
-                          </property>
-                          <property name="checkable">
-                            <bool>true</bool>
-                          </property>
-                          <property name="toolButtonStyle">
-                            <enum>Qt::ToolButtonIconOnly</enum>
-                          </property>
-                          <property name="autoRaise">
-                            <bool>true</bool>
-                          </property>
-                          <property name="arrowType">
-                            <enum>Qt::NoArrow</enum>
-                          </property>
-                        </widget>
-                      </item>
-                    </layout>
-                  </item>
-                  <item row="2" column="0">
-                    <widget class="QToolButton" name="rankedPlay">
-                      <property name="sizePolicy">
-                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                        </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                        <size>
-                          <width>0</width>
-                          <height>25</height>
-                        </size>
-                      </property>
-                      <property name="acceptDrops">
-                        <bool>false</bool>
-                      </property>
-                      <property name="toolTip">
-                        <string/>
-                      </property>
-                      <property name="whatsThis">
-                        <string extracomment="Select some factions and start searching for a 1 vs 1 match"/>
-                      </property>
-                      <property name="autoFillBackground">
-                        <bool>true</bool>
-                      </property>
-                      <property name="text">
-                        <string>Play!</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item row="1" column="0">
-                    <spacer name="verticalSpacer_2">
-                      <property name="orientation">
-                        <enum>Qt::Vertical</enum>
-                      </property>
-                      <property name="sizeType">
-                        <enum>QSizePolicy::Fixed</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                        <size>
-                          <width>20</width>
-                          <height>5</height>
-                        </size>
-                      </property>
-                    </spacer>
-                  </item>
-                </layout>
-              </widget>
-            </item>
-            <item>
-              <widget class="QLabel" name="labelHostGame">
-                <property name="font">
-                  <font>
-                    <family>Segoe UI</family>
-                    <pointsize>12</pointsize>
-                    <weight>75</weight>
-                    <bold>true</bold>
-                  </font>
-                </property>
-                <property name="text">
-                  <string>Create Custom Game</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QListWidget" name="modList">
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="focusPolicy">
-                  <enum>Qt::NoFocus</enum>
-                </property>
-                <property name="dragDropMode">
-                  <enum>QAbstractItemView::InternalMove</enum>
-                </property>
-                <property name="selectionMode">
-                  <enum>QAbstractItemView::NoSelection</enum>
-                </property>
-                <property name="iconSize">
-                  <size>
-                    <width>32</width>
-                    <height>32</height>
-                  </size>
-                </property>
-                <property name="verticalScrollMode">
-                  <enum>QAbstractItemView::ScrollPerPixel</enum>
-                </property>
-                <property name="movement">
-                  <enum>QListView::Snap</enum>
-                </property>
-                <property name="flow">
-                  <enum>QListView::TopToBottom</enum>
-                </property>
-                <property name="resizeMode">
-                  <enum>QListView::Fixed</enum>
-                </property>
-                <property name="layoutMode">
-                  <enum>QListView::SinglePass</enum>
-                </property>
-                <property name="spacing">
-                  <number>0</number>
-                </property>
-                <property name="viewMode">
-                  <enum>QListView::ListMode</enum>
-                </property>
-                <property name="sortingEnabled">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QLabel" name="labelModHint">
-                <property name="text">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Try it: FAF manages mods for you, quick and easy. Mouse over each icon for a short summary of its content &amp;amp; rules. Double-click to host a game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="wordWrap">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="acceptDrops">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string extracomment="Select some factions and start searching for a 1 vs 1 match"/>
+           </property>
+           <property name="autoFillBackground">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Play!</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>5</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
       </item>
-      <item row="0" column="1">
-        <widget class="QFrame" name="listFrame">
-          <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-          </property>
-          <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-          </property>
-          <property name="lineWidth">
-            <number>0</number>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-            <property name="margin">
-              <number>0</number>
-            </property>
-            <item>
-              <widget class="QFrame" name="gameListHeaderFrame">
-                <property name="frameShape">
-                  <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                  <enum>QFrame::Raised</enum>
-                </property>
-                <property name="lineWidth">
-                  <number>0</number>
-                </property>
-                <layout class="QHBoxLayout" name="gameListHeaderLayout">
-                  <item>
-                    <widget class="QLabel" name="labelSortGames">
-                      <property name="sizePolicy">
-                        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                        </sizepolicy>
-                      </property>
-                      <property name="palette">
-                        <palette>
-                          <active/>
-                          <inactive/>
-                          <disabled/>
-                        </palette>
-                      </property>
-                      <property name="font">
-                        <font>
-                          <family>Segoe UI</family>
-                          <pointsize>12</pointsize>
-                          <weight>75</weight>
-                          <bold>true</bold>
-                        </font>
-                      </property>
-                      <property name="text">
-                        <string>Sort Games</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item>
-                    <widget class="QComboBox" name="sortGamesComboBox">
-                      <property name="sizePolicy">
-                        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                        </sizepolicy>
-                      </property>
-                    </widget>
-                  </item>
-                  <item>
-                    <widget class="QCheckBox" name="hideGamesWithPw">
-                      <property name="text">
-                        <string>Hide Private Games</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item>
-                    <widget class="QLabel" name="labelJoinGame">
-                      <property name="palette">
-                        <palette>
-                          <active/>
-                          <inactive/>
-                          <disabled/>
-                        </palette>
-                      </property>
-                      <property name="font">
-                        <font>
-                          <family>Segoe UI</family>
-                          <pointsize>12</pointsize>
-                          <weight>75</weight>
-                          <bold>true</bold>
-                        </font>
-                      </property>
-                      <property name="text">
-                        <string>Custom Games</string>
-                      </property>
-                      <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                      </property>
-                    </widget>
-                  </item>
-                </layout>
-              </widget>
-            </item>
-            <item>
-              <widget class="QListWidget" name="gameList">
-                <property name="focusPolicy">
-                  <enum>Qt::NoFocus</enum>
-                </property>
-                <property name="selectionMode">
-                  <enum>QAbstractItemView::NoSelection</enum>
-                </property>
-                <property name="iconSize">
-                  <size>
-                    <width>100</width>
-                    <height>100</height>
-                  </size>
-                </property>
-                <property name="textElideMode">
-                  <enum>Qt::ElideMiddle</enum>
-                </property>
-                <property name="verticalScrollMode">
-                  <enum>QAbstractItemView::ScrollPerPixel</enum>
-                </property>
-                <property name="horizontalScrollMode">
-                  <enum>QAbstractItemView::ScrollPerPixel</enum>
-                </property>
-                <property name="movement">
-                  <enum>QListView::Static</enum>
-                </property>
-                <property name="flow">
-                  <enum>QListView::LeftToRight</enum>
-                </property>
-                <property name="resizeMode">
-                  <enum>QListView::Adjust</enum>
-                </property>
-                <property name="viewMode">
-                  <enum>QListView::IconMode</enum>
-                </property>
-                <property name="uniformItemSizes">
-                  <bool>true</bool>
-                </property>
-                <property name="sortingEnabled">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+      <item>
+       <widget class="QLabel" name="labelHostGame">
+        <property name="font">
+         <font>
+          <family>Segoe UI</family>
+          <pointsize>12</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Create Custom Game</string>
+        </property>
+       </widget>
       </item>
-    </layout>
-  </widget>
-  <resources/>
-  <connections/>
+      <item>
+       <widget class="QListWidget" name="modList">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="dragDropMode">
+         <enum>QAbstractItemView::InternalMove</enum>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="verticalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <property name="movement">
+         <enum>QListView::Snap</enum>
+        </property>
+        <property name="flow">
+         <enum>QListView::TopToBottom</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Fixed</enum>
+        </property>
+        <property name="layoutMode">
+         <enum>QListView::SinglePass</enum>
+        </property>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="viewMode">
+         <enum>QListView::ListMode</enum>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelModHint">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Try it: FAF manages mods for you, quick and easy. Mouse over each icon for a short summary of its content &amp;amp; rules. Double-click to host a game.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QFrame" name="listFrame">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QFrame" name="gameListHeaderFrame">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QHBoxLayout" name="gameListHeaderLayout">
+         <item>
+          <widget class="QLabel" name="labelSortGames">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="palette">
+            <palette>
+             <active/>
+             <inactive/>
+             <disabled/>
+            </palette>
+           </property>
+           <property name="font">
+            <font>
+             <family>Segoe UI</family>
+             <pointsize>12</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Sort Games</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="sortGamesComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="hideGamesWithPw">
+           <property name="text">
+            <string>Hide Private Games</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelJoinGame">
+           <property name="palette">
+            <palette>
+             <active/>
+             <inactive/>
+             <disabled/>
+            </palette>
+           </property>
+           <property name="font">
+            <font>
+             <family>Segoe UI</family>
+             <pointsize>12</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Custom Games</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QListWidget" name="gameList">
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>100</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="textElideMode">
+         <enum>Qt::ElideMiddle</enum>
+        </property>
+        <property name="verticalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <property name="horizontalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <property name="movement">
+         <enum>QListView::Static</enum>
+        </property>
+        <property name="flow">
+         <enum>QListView::LeftToRight</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Adjust</enum>
+        </property>
+        <property name="viewMode">
+         <enum>QListView::IconMode</enum>
+        </property>
+        <property name="uniformItemSizes">
+         <bool>true</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -171,8 +171,7 @@ class GamesWidget(FormClass, BaseClass):
 
         self.rankedPlay.clicked.connect(self.startSubRandomRankedSearch)
         self.rankedPlay.show()
-        self.labelRankedHint.hide()
-        self.labelSubsetRankedHint.show()
+        self.labelRankedHint.show()
         for faction, icon in self._ranked_icons.items():
             try:
                 icon.clicked.disconnect()


### PR DESCRIPTION
There are 2 RankHint labels with slightly different text, only one 'subsetRankHint' was used. I removed the the older unused "RankHint" and renamed 'subsetRankHint' to 'RankHint'.

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
