### PR TITLE
718 refactor vault downloads

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Add Friend/Foe feature for IRC users (#609, #657)
 * Replace game quality in the play tab (NOT in the lobby) by average rating (#687, #688)
 * Split replay widget to separate classes (#698, #699)
+* Cleanup and unify map & mod download behaviour (#718, #719)
 
 Contributors:
  - Wesmania

--- a/src/downloadManager/__init__.py
+++ b/src/downloadManager/__init__.py
@@ -119,52 +119,41 @@ class downloadManager(QtCore.QObject):
         self.client = parent
         self.nam = QNetworkAccessManager(self)
 
-        self.nam.finished.connect(self.finishedDownload)
-
         self.modRequests = {}
         self.mapRequests = {}
         self.mapRequestsItem = []
 
-    @QtCore.pyqtSlot(QNetworkReply)
-    def finishedDownload(self, reply):
-        ''' finishing downloads '''
-        # mark reply for collection by Qt
-        reply.deleteLater()
-        urlstring = reply.url().toString()
+    @QtCore.pyqtSlot(FileDownload)
+    def finishedDownload(self, dler):
+        urlstring = dler.addr
+        name = os.path.basename(urlstring)
         logger.info("Finished download from " + urlstring)
+        dler.dest.close()
+
         reqlist = []
         if urlstring in self.mapRequests: reqlist = self.mapRequests[urlstring]
         if urlstring in self.modRequests: reqlist = self.modRequests[urlstring]
-        if reqlist:
-            #save the map from cache
-            name = os.path.basename(reply.url().toString())
-            pathimg = os.path.join(util.CACHE_DIR, name)
-            img = QtCore.QFile(pathimg)
-            img.open(QtCore.QIODevice.WriteOnly)
-            img.write(reply.readAll())
-            img.close()
-            if os.path.exists(pathimg):
-                #Create alpha-mapped preview image
-                try:
-                    pass # the server already sends 100x100 pic
-#                    img = QtWidgets.QImage(pathimg).scaled(100,100)
-#                    img.save(pathimg)
-                except:
-                    pathimg = "games/unknown_map.png"
-                    logger.info("Failed to resize " + name)
-            else :
-                pathimg = "games/unknown_map.png"
-                logger.debug("Web Preview failed for: " + name)
-            logger.debug("Web Preview used for: " + name)
-            for requester in reqlist:
-                if requester:
-                    if requester in self.mapRequestsItem:
-                        requester.setIcon(0, util.THEME.icon(pathimg, False))
-                        self.mapRequestsItem.remove(requester)
-                    else:
-                        requester.setIcon(util.THEME.icon(pathimg, False))
-            if urlstring in self.mapRequests: del self.mapRequests[urlstring]
-            if urlstring in self.modRequests: del self.modRequests[urlstring]
+        if not reqlist:
+            dler.dest.remove()
+            return
+
+        if urlstring in self.mapRequests: del self.mapRequests[urlstring]
+        if urlstring in self.modRequests: del self.modRequests[urlstring]
+
+        #save the map from cache
+        if not dler.succeeded():
+            dler.dest.remove()
+            pathimg = "games/unknown_map.png"
+            logger.debug("Web Preview failed for: " + name)
+
+        logger.debug("Web Preview used for: " + name)
+        for requester in reqlist:
+            if requester:
+                if requester in self.mapRequestsItem:
+                    requester.setIcon(0, util.THEME.icon(pathimg, False))
+                    self.mapRequestsItem.remove(requester)
+                else:
+                    requester.setIcon(util.THEME.icon(pathimg, False))
 
     @QtCore.pyqtSlot(QNetworkReply.NetworkError)
     def downloadError(self, networkError):
@@ -178,6 +167,12 @@ class downloadManager(QtCore.QObject):
     def progress(self, rcv, total):
         logger.info("received " + rcv + "out of" + total + " bytes")
 
+    def _get_cachefile(self, name):
+        pathimg = os.path.join(util.CACHE_DIR, name)
+        img = QtCore.QFile(pathimg)
+        img.open(QtCore.QIODevice.WriteOnly)
+        return img
+
     def downloadMap(self, name, requester, item=False):
         '''
         Downloads a preview image from the web for the given map name
@@ -187,23 +182,28 @@ class downloadManager(QtCore.QObject):
         if len(name) == 0:
             return
 
-        url = QtCore.QUrl(VAULT_PREVIEW_ROOT + urllib.parse.quote(name) + ".png")
-        if not url.toString() in self.mapRequests:
-            logger.info("Searching map preview for: " + name + " from " + url.toString())
-            self.mapRequests[url.toString()] = []
-            request = QNetworkRequest(url)
-            rpl = self.nam.get(request)
-            self.mapRequests[url.toString()].append(requester)
-        else :
-            self.mapRequests[url.toString()].append(requester)
+        url = VAULT_PREVIEW_ROOT + urllib.parse.quote(name) + ".png"
+        if not url in self.mapRequests:
+            logger.info("Searching map preview for: " + name + " from " + url)
+            self.mapRequests[url] = []
+
+            img = self._get_cachefile(name)
+            downloader = FileDownload(self.nam, url, img, finished = self.finishedDownload)
+            downloader.blocksize = None
+            downloader.run()
+
+        self.mapRequests[url].append(requester)
         if item:
             self.mapRequestsItem.append(requester)
 
-    def downloadModPreview(self, strurl, requester):
-        url = QtCore.QUrl(strurl)
-        if not url.toString() in self.modRequests:
-            logger.debug("Searching mod preview for: " + os.path.basename(strurl).rsplit('.',1)[0])
-            self.modRequests[url.toString()] = []
-            request = QNetworkRequest(url)
-            rpl = self.nam.get(request)
-        self.modRequests[url.toString()].append(requester)
+    def downloadModPreview(self, url, requester):
+        if not url in self.modRequests:
+            logger.debug("Searching mod preview for: " + os.path.basename(url).rsplit('.',1)[0])
+            self.modRequests[url] = []
+
+            img = self._get_cachefile(name)
+            downloader = FileDownload(self.nam, url, img, finished = self.finishedDownload)
+            downloader.blocksize = None
+            downloader.run()
+
+        self.modRequests[url].append(requester)

--- a/src/downloadManager/__init__.py
+++ b/src/downloadManager/__init__.py
@@ -9,6 +9,106 @@ from config import Settings
 
 logger= logging.getLogger(__name__)
 
+
+class FileDownload(object):
+    """
+    A simple async one-shot file downloader.
+    """
+    def __init__(self, nam, addr, dest, start=lambda _: None, progress=lambda _: None, finished=lambda _: None):
+        self._nam = nam
+        self.addr = addr
+        self.dest = dest
+
+        self.canceled = False
+        self.error = False
+
+        self.blocksize = 8192
+        self.bytes_total = 0
+        self.bytes_progress = 0
+
+        self._dfile = None
+
+        self.cb_start = start
+        self.cb_progress = progress
+        self.cb_finished = finished
+
+        self._reading = False
+        self._running = False
+        self._sock_finished = False
+
+    def _stop(self):
+        ran = self._running
+        self._running = False
+        if ran:
+            self._finish()
+
+    def _error(self):
+        self.error = True
+        self._stop()
+
+    def cancel(self):
+        self.canceled = True
+        self._stop()
+
+    def _finish(self):
+        if self._dfile is not None:
+            self._dfile.close()
+            self._dfile = None
+        self.cb_finished(self)
+
+    def run(self):
+        self._running = True
+        req = QNetworkRequest(QtCore.QUrl(self.addr))
+        req.setRawHeader(b'User-Agent', b"FAF Client")
+        req.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
+        req.setMaximumRedirectsAllowed(3)
+
+        self.cb_start(self)
+
+        self._dfile = self._nam.get(req)
+        self._dfile.error.connect(self._error)
+        self._dfile.finished.connect(self._atFinished)
+        self._dfile.downloadProgress.connect(self._atProgress)
+        self._dfile.readyRead.connect(self._kick_read)
+        self._kick_read()
+
+    def _atFinished(self):
+        self._sock_finished = True
+        self._kick_read()
+
+    def _atProgress(self, recv, total):
+        self.bytes_progress = recv
+        self.bytes_total = total
+
+    def _kick_read(self):    # Don't run the read loop more than once at a time
+        if self._reading:
+            return
+        self._reading = True
+        self._read()
+        self._reading = False
+
+    def _read(self):
+        while self._dfile.bytesAvailable() > 0 and self._running:
+            self._readloop()
+        if self._sock_finished:
+            # Sock can be marked as finished either before read or inside readloop
+            # Either way we've read everything after it was marked
+            self._stop()
+
+    def _readloop(self):
+            bs = self.blocksize if self.blocksize is not None else self._dfile.bytesAvailable() 
+            self.dest.write(self._dfile.read(bs))
+            self.cb_progress(self)
+
+    def succeeded(self):
+        return not self.error and not self.canceled
+
+    def waitForCompletion(self):
+        waitFlag = QtCore.QEventLoop.WaitForMoreEvents
+        while self._running:
+            QtWidgets.QApplication.processEvents(waitFlag)
+
+
 VAULT_PREVIEW_ROOT = "{}/faf/vault/map_previews/small/".format(Settings.get('content/host'))
 
 class downloadManager(QtCore.QObject):

--- a/src/vault/dialogs.py
+++ b/src/vault/dialogs.py
@@ -1,0 +1,66 @@
+from downloadManager import FileDownload
+from PyQt5 import QtCore, QtNetwork, QtWidgets
+import zipfile
+
+class VaultDownloadDialog(object):
+    # Result codes
+    SUCCESS = 0
+    CANCELED = 1
+    DL_ERROR = 2
+    UNKNOWN_ERROR = 3
+
+    def __init__(self, dler, title, label, silent = False):
+        self._silent = silent
+        self._result = None
+
+        self._dler = dler
+        self._dler.cb_start = self._start
+        self._dler.cb_progress = self._cont
+        self._dler.cb_finished = self._finished
+        self._dler.blocksize = 8192
+
+        self._progress = QtWidgets.QProgressDialog()
+        self._progress.setWindowTitle(title)
+        self._progress.setLabelText(label)
+        if not self._silent:
+            self._progress.setCancelButtonText("Cancel")
+        else:
+            self._progress.setCancelButton(None)
+        self._progress.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint)
+        self._progress.setAutoReset(False)
+        self._progress.setModal(1)
+        self._progress.canceled.connect(self._dler.cancel)
+
+    def run(self):
+        self._progress.show()
+        self._dler.run()
+        self._dler.waitForCompletion()
+        return self._result
+
+    def _start(self, dler):
+        self._progress.setMinimum(0)
+        self._progress.setMaximum(dler.bytes_total)
+
+    def _cont(self, dler):
+        self._progress.setValue(dler.bytes_progress)
+        self._progress.setMaximum(dler.bytes_total)
+        QtWidgets.QApplication.processEvents()
+
+    def _finished(self, dler):
+        self._progress.reset()
+
+        if not dler.succeeded():
+            if dler.canceled:
+                self._result = self.CANCELED
+                return
+
+            elif dler.error:
+                self._result = self.DL_ERROR
+                return
+            else:
+                self._result = self.UNKNOWN_ERROR
+                return
+
+        self._result = self.SUCCESS
+        return
+


### PR DESCRIPTION
This code refactors downloading assets from the vault. It adds the following:

- FileDownload class for convenient download of files from a url,
- VaultDownloadDialog for presenting a modal dialog while downloading a file
- downloadVaultAsset function that uses both of the above to download a file, do logging and present other modal windows to the user,
- refactored downloadMap and downloadMod that use the above.

These changes should make adding support for downloading tutorials easy.

I'd like comments on the FileDownload class - there's some complex interactions with QNetworkReply signals that feel non-obvious and seem hard to unit test.

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
