### PR TITLE
Fix unicode errors.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,10 +9,10 @@
 * Remove redundant APPDATA_DIR loading in util (#665, #666)
 * Fix theme breakage caused by a promoted widget (#669, #670)
 * Fix random/nomads faction shown in replay info (#676)
-* Fix lobby name change not showing in Play (#690) 
+* Fix lobby name change not showing in Play (#690)
 * Add sorting games By Map, Host and Age to Play (#686)
 * Fix set mod to 'All' from chat user 'View Replays in Vault' (#695)
-* Mod dropdown-list in Replays show all mods (no scrolling) (#696) 
+* Mod dropdown-list in Replays show all mods (no scrolling) (#696)
 * Recognise `nosuchnick` irc server message
 * Purge last remains of (long removed) mumble integration (#681, #682)
 * Don't use eval in legacy updater (#715, #716)
@@ -20,7 +20,8 @@
 * Clean up layout of login widget (#652, #653)
 * Use "foo" instead of user password in develop mode (#712, #653)
 * Remove unused label from GamesWidget (#717)
-* Fix for user in chat shown in long gone games (#705) 
+* Fix for user in chat shown in long gone games (#705)
+* Fix some unicode handling problems (#689,  #721)
 
 Contributors:
   - Wesmania

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -2,6 +2,7 @@ import sys
 import os
 import subprocess
 import getpass
+import codecs
 from ctypes import *
 
 from PyQt4.QtGui import QDesktopServices, QMessageBox
@@ -480,13 +481,13 @@ def readfile(filename, themed=True):
     '''
     if themed:
         if __themedir and os.path.isfile(os.path.join(__themedir, filename)):
-            result = open(os.path.join(__themedir, filename))
+            result = codecs.open(os.path.join(__themedir, filename), encoding='utf-8')
             logger.debug(u"Read themed file: " + filename)
         else:
-            result = open(os.path.join(COMMON_DIR, filename))
+            result = codecs.open(os.path.join(COMMON_DIR, filename), encoding='utf-8')
             logger.debug(u"Read common file: " + filename)
     else:
-        result = open(filename)
+        result = codecs.open(filename, encoding='utf-8')
         logger.debug(u"Read unthemed file: " + filename)
 
     data = result.read()

--- a/src/vault/__init__.py
+++ b/src/vault/__init__.py
@@ -58,12 +58,15 @@ class MapVault(QtCore.QObject):
                 util.themeurl("vault/style.css"))
 
         ROOT = Settings.get('content/host')
-        self.ui.setUrl(
-            QtCore.QUrl("{route}/faf/vault/maps.php?username={user}"
-                        "&pwdhash={pwdhash}".format(
-                            route=Settings.get('content/host'),
-                            user=self.client.login,
-                            pwdhash=self.client.password)))
+
+        url = QtCore.QUrl(ROOT)
+        url.setPath("/faf/vault/maps.php")
+        url.addQueryItem('username', self.client.login)
+        url.addQueryItem('pwdhash', self.client.password)
+
+        logger.info(url)
+
+        self.ui.setUrl(url)
 
     @QtCore.pyqtSlot()
     def addScript(self):


### PR DESCRIPTION
* Use QUrl composition for map vault url

Avoids unicode errors and is much cleaner code.

*  Make `utils.readfile` read utf-8

This is the intended behaviour - everything using `utils.readfile` already (uselessly) coerces the result to unicode.

Fixes #689

Initial PR:

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [X] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
