### PR TITLE
Refactor automatic login

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 * Remove unused label from GamesWidget (#717)
 * Fix for user in chat shown in long gone games (#705)
 * Fix some unicode handling problems (#689,  #721)
+* Rework autologin logic to fix loops at login error (#720, #722)
 
 Contributors:
   - Wesmania

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -92,7 +92,6 @@ def runFAF():
     if not faf_client.doConnect():
         return
 
-    faf_client.doLogin()
     faf_client.show()
     # Main update loop
     QtGui.QApplication.exec_()

--- a/src/client/login.py
+++ b/src/client/login.py
@@ -26,8 +26,8 @@ class LoginWidget(FormClass, BaseClass):
         password = self.passwordField.text()
         hashed_password = util.password_hash(password)
         login = self.loginField.text().strip()
-        self.finished.emit(login, hashed_password)
         self.accept()
+        self.finished.emit(login, hashed_password)
 
     @QtCore.pyqtSlot()
     def on_rejected(self):


### PR DESCRIPTION
Automatic login is now governed by a separate variable that we can
enable (if we successfully logged in, for example) or disable (if we
failed to login or received a critical server error).

We also move logging in by either login window or automatically to a
single method, and call it instead of directly showing the window or
doing autologin.

Fixes #720.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [x] Rebase onto develop
- [x] Add changelog entry
- [ ] Remove this entire template section
