### PR TITLE
feature - singleline the layout of Vaults\Mods

### DIFF
--- a/res/modvault/modvault.ui
+++ b/res/modvault/modvault.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>625</width>
+    <width>729</width>
     <height>376</height>
    </rect>
   </property>
@@ -42,6 +42,12 @@
            </property>
            <item>
             <widget class="QLineEdit" name="searchInput">
+             <property name="minimumSize">
+              <size>
+               <width>110</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="maximumSize">
               <size>
                <width>250</width>
@@ -58,33 +64,6 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>150</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uploadButton">
-             <property name="text">
-              <string>Upload Mod</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <property name="topMargin">
-            <number>10</number>
-           </property>
-           <item>
             <widget class="QLabel" name="LabelSort">
              <property name="maximumSize">
               <size>
@@ -97,12 +76,18 @@
              </property>
             </widget>
            </item>
-           <item alignment="Qt::AlignLeft">
+           <item>
             <widget class="QComboBox" name="SortType">
              <property name="minimumSize">
               <size>
-               <width>85</width>
+               <width>110</width>
                <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
               </size>
              </property>
              <item>
@@ -136,6 +121,18 @@
            </item>
            <item>
             <widget class="QComboBox" name="ShowType">
+             <property name="minimumSize">
+              <size>
+               <width>110</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <item>
               <property name="text">
                <string>All</string>
@@ -174,13 +171,13 @@
             </widget>
            </item>
            <item>
-            <spacer name="horizontalSpacer_2">
+            <spacer name="horizontalSpacer">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>150</width>
                <height>20</height>
               </size>
              </property>
@@ -190,6 +187,13 @@
             <widget class="QPushButton" name="UIButton">
              <property name="text">
               <string>Manage UI Mods</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="uploadButton">
+             <property name="text">
+              <string>Upload Mod</string>
              </property>
             </widget>
            </item>

--- a/res/modvault/modvault.ui
+++ b/res/modvault/modvault.ui
@@ -25,181 +25,182 @@
    </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="margin">
+      <number>5</number>
+     </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <property name="spacing">
+        <number>5</number>
+       </property>
+       <property name="leftMargin">
+        <number>5</number>
+       </property>
        <property name="topMargin">
         <number>10</number>
        </property>
        <property name="rightMargin">
-        <number>10</number>
+        <number>5</number>
+       </property>
+       <property name="bottomMargin">
+        <number>5</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <widget class="QLineEdit" name="searchInput">
+         <property name="minimumSize">
+          <size>
+           <width>110</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>250</width>
+           <height>16777215</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="searchButton">
+         <property name="text">
+          <string>Server Search</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="LabelSort">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Sort</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="SortType">
+         <property name="minimumSize">
+          <size>
+           <width>110</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <property name="topMargin">
-            <number>10</number>
-           </property>
-           <item>
-            <widget class="QLineEdit" name="searchInput">
-             <property name="minimumSize">
-              <size>
-               <width>110</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>250</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="searchButton">
-             <property name="text">
-              <string>Server Search</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="LabelSort">
-             <property name="maximumSize">
-              <size>
-               <width>50</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Sort</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="SortType">
-             <property name="minimumSize">
-              <size>
-               <width>110</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <item>
-              <property name="text">
-               <string>Alphabetic</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Upload Date</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Rating</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Downloads</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="labelShow">
-             <property name="text">
-              <string>Show</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QComboBox" name="ShowType">
-             <property name="minimumSize">
-              <size>
-               <width>110</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <item>
-              <property name="text">
-               <string>All</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>UI Only</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Sim only</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Big Mods</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Small Mods</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Uploaded by You</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Installed</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>150</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="UIButton">
-             <property name="text">
-              <string>Manage UI Mods</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uploadButton">
-             <property name="text">
-              <string>Upload Mod</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <property name="text">
+           <string>Alphabetic</string>
+          </property>
          </item>
-        </layout>
+         <item>
+          <property name="text">
+           <string>Upload Date</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Rating</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Downloads</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelShow">
+         <property name="text">
+          <string>Show</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="ShowType">
+         <property name="minimumSize">
+          <size>
+           <width>110</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <item>
+          <property name="text">
+           <string>All</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>UI Only</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Sim only</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Big Mods</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Small Mods</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Uploaded by You</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Installed</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>150</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="UIButton">
+         <property name="text">
+          <string>Manage UI Mods</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="uploadButton">
+         <property name="text">
+          <string>Upload Mod</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
This will put all textboxes and buttons in a single line and cleanup the Layout.

QtDesigner:
before:
![fafclient-modvault-ui before](https://cloud.githubusercontent.com/assets/19195504/25807842/7ff73448-3408-11e7-9048-36f940aa8885.jpg)
after:
![fafclient-modvault-ui after](https://cloud.githubusercontent.com/assets/19195504/25807887/9ddfe3ec-3408-11e7-810c-7b57df5e6bc1.jpg)

FAFclient:
before:
![fafclient-mods-elements before](https://cloud.githubusercontent.com/assets/19195504/25807918/b89bc160-3408-11e7-8902-c31fa4947542.jpg)
after:
![fafclient-mods-elements after](https://cloud.githubusercontent.com/assets/19195504/25807925/c2eece5a-3408-11e7-9abe-3c377968a063.jpg)
