### PR TITLE
Log errors from faf-uid executable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,9 +3,11 @@
 
 * Single-Line Mod-Vault toolbar (#730)
 * Pin UID version in appveyor
+* Log errors from faf-uid executable (#741, #742)
 
 Contributors:
   - Grothe
+  - Wesmania
 
 
 0.12.5

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -681,13 +681,18 @@ def uniqueID(user, session):
         except Exception as e:
             QMessageBox.critical(None, "WMI service missing", "FAF requires the 'Windows Management Instrumentation' service for smurf protection. This service could not be found.")
     try:
-        # on error, the uid exe returns 1 which will result in a CalledProcessError exception
-        return subprocess.check_output(["faf-uid", session], env=env)
+        uid_p = subprocess.Popen(["faf-uid", session], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = uid_p.communicate()
+        if uid_p.returncode != 0:
+            logger.error("UniqueID executable error:")
+            for line in err.split('\n'):
+                logger.error(line)
+            return None
+        else:
+            return out
     except OSError as err:
         logger.error("UniqueID error finding the executable: {}".format(err))
-    except subprocess.CalledProcessError as exc:
-        logger.error("UniqueID executable error: {}".format(exc.output))
-    return None
+        return None
 
 
 def userNameAction(parent, caption, action):


### PR DESCRIPTION
faf-uid uses stderr to communicate errors. Use Popen to read stdout and
stderr separately, then use stderr to print faf-uid errors instead of
stdout.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
