### PR TITLE
Cleanup resize behaviour for client / channel

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Pin UID version in appveyor
 * Log errors from faf-uid executable (#741, #742)
 * Add menu option: Show paths for maps, mods & replays (#735)
+* Slightly clean up client resize logic (#747, #748)
 
 Contributors:
   - Grothe

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -100,11 +100,6 @@ class Channel(FormClass, BaseClass):
         self.chatEdit.returnPressed.connect(self.sendLine)
         self.chatEdit.setChatters(self.chatters)
 
-        self.lobby.client.doneresize.connect(self.resizing)
-
-        self.resizeTimer = QtCore.QTimer(self)
-        self.resizeTimer.timeout.connect(self.canresize)
-
     def joinChannel(self, index):
         """ join another channel """
         channel = self.channelsComboBox.itemText(index)
@@ -118,13 +113,12 @@ class Channel(FormClass, BaseClass):
         if keyevent.key() == 67:
             self.chatArea.copy()
 
-    def canresize(self):
-        if self.isVisible():
-            self.chatArea.setLineWrapColumnOrWidth(self.chatArea.size().width() - 20)  # Hardcoded, but seems to be enough (tabstop was a bit large)
-            self.resizeTimer.stop()
+    def resizeEvent(self, size):
+        BaseClass.resizeEvent(self, size)
+        self.setTextWidth()
 
-    def resizing(self):
-        self.resizeTimer.start(10)
+    def setTextWidth(self):
+        self.chatArea.setLineWrapColumnOrWidth(self.chatArea.size().width() - 20)  # Hardcoded, but seems to be enough (tabstop was a bit large)
 
     def showEvent(self, event):
         self.stopBlink()

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -101,9 +101,6 @@ class ClientWindow(FormClass, BaseClass):
     state_changed = QtCore.pyqtSignal(object)
     authorized = QtCore.pyqtSignal(object)
 
-    # This signal is emitted when the client is done rezising
-    doneresize = QtCore.pyqtSignal()
-
     # These signals notify connected modules of game state changes (i.e. reasons why FA is launched)
     viewingReplay = QtCore.pyqtSignal(QtCore.QUrl)
 
@@ -187,11 +184,6 @@ class ClientWindow(FormClass, BaseClass):
         self.lobby_dispatch["update"] = self.handle_update
         self.lobby_dispatch["welcome"] = self.handle_welcome
         self.lobby_dispatch["authentication_failed"] = self.handle_authentication_failed
-
-        # Timer for resize events
-        self.resizeTimer = QtCore.QTimer(self)
-        self.resizeTimer.timeout.connect(self.resized)
-        self.preferedSize = 0
 
         # Process used to run Forged Alliance (managed in module fa)
         fa.instance.started.connect(self.startedFA)
@@ -708,13 +700,6 @@ class ClientWindow(FormClass, BaseClass):
                 return
 
         return QtGui.QMainWindow.closeEvent(self, event)
-
-    def resizeEvent(self, size):
-        self.resizeTimer.start(400)
-
-    def resized(self):
-        self.resizeTimer.stop()
-        self.doneresize.emit()
 
     def initMenus(self):
         self.actionLink_account_to_Steam.triggered.connect(partial(self.open_url, Settings.get("STEAMLINK_URL")))


### PR DESCRIPTION
I think there was once an attempt of optimization, with resize signals
from the client. Thet definitely don't work since the client eats a lot
of CPU while resized anyway, signals are only used in one place and
cause some timers to potentially get called a hundred times a second,
Let's clean this up and worry about resize performance some other day.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
