### PR TITLE
Fix wrong channel order caused by 5a8ac3c4a1ec

### DIFF
--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -128,10 +128,12 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
                     self.channels[channel].chatters[player].avatarItem.setIcon(QtGui.QIcon(util.respix(reply.url().toString())))
                     self.channels[channel].chatters[player].avatarItem.setToolTip(self.channels[channel].chatters[player].avatarTip)
 
-    def addChannel(self, name, channel):
+    def addChannel(self, name, channel, index = None):
         self.channels[name] = channel
-        self.addTab(self.channels[name], name)
-        channel.setTextWidth()
+        if index is None:
+            self.addTab(self.channels[name], name)
+        else:
+            self.insertTab(index, self.channels[name], name)
 
     def closeChannel(self, index):
         """
@@ -277,14 +279,14 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
         if channel not in self.channels:
             newch = Channel(self, channel)
             if channel.lower() in self.crucialChannels:
-                self.insertTab(1, newch, channel)  # CAVEAT: This is assumes a server tab exists.
+                self.addChannel(channel, newch, 1)  # CAVEAT: This is assumes a server tab exists.
                 self.client.localBroadcast.connect(newch.printRaw)
                 newch.printAnnouncement("Welcome to Forged Alliance Forever!", "red", "+3")
                 newch.printAnnouncement("Check out the wiki: http://wiki.faforever.com for help with common issues.", "white", "+1")
                 newch.printAnnouncement("", "black", "+1")
                 newch.printAnnouncement("", "black", "+1")
-
-            self.addChannel(channel, newch)
+            else:
+                self.addChannel(channel, newch)
 
             if channel.lower() in self.crucialChannels:  # Make the crucial channels not closeable, and make the last one the active one
                 self.setCurrentWidget(self.channels[channel])

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -122,6 +122,7 @@ class Channel(FormClass, BaseClass):
 
     def showEvent(self, event):
         self.stopBlink()
+        self.setTextWidth()
         return BaseClass.showEvent(self, event)
 
     @QtCore.pyqtSlot()


### PR DESCRIPTION
#748 accidentally changed chat tab order. This PR fixes it.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
