### PR TITLE
[WIP] Set log level on module loggers from settings

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -188,6 +188,5 @@ if Settings.get('client/logs/console', False, type=bool):
     devh = logging.StreamHandler()
     devh.setFormatter(logging.Formatter('%(asctime)s %(levelname)-8s %(name)-30s %(message)s'))
     logging.getLogger().addHandler(devh)
-    logging.getLogger().setLevel(Settings.get('client/logs/level', type=int))
 
 logging.getLogger().info("FAF version: {} Environment: {}".format(VERSION, environment))

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -1,4 +1,5 @@
 import logging
+from config import Settings
 
 
 def with_logger(cls):
@@ -6,6 +7,9 @@ def with_logger(cls):
     cls_name = cls.__name__
     module = cls.__module__
     assert module is not None
-    cls_name = module + '.' + cls_name
-    setattr(cls, attr_name, logging.getLogger(cls_name))
+    logger_name = module + '.' + cls_name
+    logger = logging.getLogger(logger_name)
+    loglevel = Settings.get('client/logs/' + module, default=logging.INFO, type=int)
+    logger.setLevel(loglevel)
+    setattr(cls, attr_name, logger)
     return cls

--- a/src/downloadManager/__init__.py
+++ b/src/downloadManager/__init__.py
@@ -5,11 +5,11 @@ import logging
 import os
 import util
 import warnings
+from decorators import with_logger
 from config import Settings
 
-logger= logging.getLogger(__name__)
 
-
+@with_logger
 class FileDownload(object):
     """
     A simple async one-shot file downloader.
@@ -111,6 +111,7 @@ class FileDownload(object):
 
 VAULT_PREVIEW_ROOT = "{}/faf/vault/map_previews/small/".format(Settings.get('content/host'))
 
+@with_logger
 class downloadManager(QtCore.QObject):
     ''' This class allows downloading stuff in the background'''
 
@@ -127,7 +128,7 @@ class downloadManager(QtCore.QObject):
     def finishedDownload(self, dler):
         urlstring = dler.addr
         name = os.path.basename(urlstring)
-        logger.info("Finished download from " + urlstring)
+        self._logger.info("Finished download from " + urlstring)
         dler.dest.close()
 
         reqlist = []
@@ -144,9 +145,9 @@ class downloadManager(QtCore.QObject):
         if not dler.succeeded():
             dler.dest.remove()
             pathimg = "games/unknown_map.png"
-            logger.debug("Web Preview failed for: " + name)
+            self._logger.debug("Web Preview failed for: " + name)
 
-        logger.debug("Web Preview used for: " + name)
+        self._logger.debug("Web Preview used for: " + name)
         for requester in reqlist:
             if requester:
                 if requester in self.mapRequestsItem:
@@ -157,15 +158,15 @@ class downloadManager(QtCore.QObject):
 
     @QtCore.pyqtSlot(QNetworkReply.NetworkError)
     def downloadError(self, networkError):
-        logger.info("Network Error")
+        self._logger.info("Network Error")
 
     @QtCore.pyqtSlot()
     def readyRead(self):
-        logger.info("readyRead")
+        self._logger.info("readyRead")
 
     @QtCore.pyqtSlot(int, int)
     def progress(self, rcv, total):
-        logger.info("received " + rcv + "out of" + total + " bytes")
+        self._logger.info("received " + rcv + "out of" + total + " bytes")
 
     def _get_cachefile(self, name):
         pathimg = os.path.join(util.CACHE_DIR, name)
@@ -184,7 +185,7 @@ class downloadManager(QtCore.QObject):
 
         url = VAULT_PREVIEW_ROOT + urllib.parse.quote(name) + ".png"
         if not url in self.mapRequests:
-            logger.info("Searching map preview for: " + name + " from " + url)
+            self._logger.info("Searching map preview for: " + name + " from " + url)
             self.mapRequests[url] = []
 
             img = self._get_cachefile(name)
@@ -198,7 +199,7 @@ class downloadManager(QtCore.QObject):
 
     def downloadModPreview(self, url, requester):
         if not url in self.modRequests:
-            logger.debug("Searching mod preview for: " + os.path.basename(url).rsplit('.',1)[0])
+            self._logger.debug("Searching mod preview for: " + os.path.basename(url).rsplit('.',1)[0])
             self.modRequests[url] = []
 
             img = self._get_cachefile(name)


### PR DESCRIPTION
Introduces `client/logs/<module>` per-module log level setting.

This makes it possible to use log levels in a much more granular way and
significantly reduce useless logspam when debugging.

Also contains two clean-up commits to

* Remove explicit log level setting from console log handler
* Use the `with_logger` decorator instead of manual logger instantiation

Initial PR:

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [X] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
