### PR TITLE
fix live game ended online replay doubleclick

### DIFF
--- a/src/model/game.py
+++ b/src/model/game.py
@@ -180,11 +180,11 @@ class Game(QObject):
         query = QUrlQuery()
         query.addQueryItem("map", self.mapname)
         query.addQueryItem("mod", self.featured_mod)
+        query.addQueryItem("uid", str(self.uid))
 
         if self.state == GameState.OPEN:
             url.setScheme("fafgame")
             url.setPath("/" + str(player_id))
-            query.addQueryItem("uid", str(self.uid))
         else:
             url.setScheme("faflive")
             url.setPath("/" + str(self.uid) + "/" + str(player_id) + ".SCFAreplay")


### PR DESCRIPTION
if a search gets old, shown 'playing' games might already have ended, 
which leads to a bad click experience, we don't want that.

check if live-game is still running, else give option to start replay, fix #783
check for (a) player still in clicked game (need to add uid to url)
add error message if replay ended irregular
