### PR TITLE
add pyqt5 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cx_Freeze
 ipaddress
 pathlib
+pyqt5
 pytest
 pytest-cov
 pytest-mock


### PR DESCRIPTION
No extra pyqt install needed (no more complications like with previous pyqt versions)
(and Pycharm loves this)