### PR TITLE
[WIP] fix map preview

### DIFF
--- a/src/fa/maps.py
+++ b/src/fa/maps.py
@@ -279,13 +279,13 @@ def __exportPreviewFromMap(mapname, positions=None):
         mapdir = mapname
     elif os.path.isdir(os.path.join(getUserMapsFolder(), mapname)):
         mapdir = os.path.join(getUserMapsFolder(), mapname)
-    elif os.path.isdir(os.path.join(getBaseMapsFolder(), mapname)):
-        mapdir = os.path.join(getBaseMapsFolder(), mapname)
+    elif os.path.isdir(os.path.join(getBaseMapsFolder(), mapname.upper())):
+        mapdir = os.path.join(getBaseMapsFolder(), mapname.upper())
     else:
         logger.debug("Can't find mapname in file system: " + mapname)
         return previews
 
-    mapname = os.path.basename(mapdir).lower()
+    mapname = os.path.basename(mapdir)
     mapfilename = os.path.join(mapdir, mapname.split(".")[0]+".scmap")
 
     mode = os.stat(mapdir)[0]


### PR DESCRIPTION
while trying to reproduce http://forums.faforever.com/viewtopic.php?f=2&t=4507&start=320#p152255 I deleted my cache folder content and noticed that no previews are generated for default scmp-maps.

On my retail installation the scmp-maps are stored uppercase on disk and this little patch made the preview work. 
But I don't know if this breaks  some other thumbnail stuff later.