### PR TITLE
Fix downloader deallocated before finishing download

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * Fix join hosted game from chat user (#796)
 * Leftover Qt5 fixes
 * Fix fa updater not cancelling download (#802, #803)
+* Fix regression - map and mod previews not downloading correctly (#804, #805)
 
 Contributors:
  - Wesmania

--- a/src/util/theme.py
+++ b/src/util/theme.py
@@ -351,4 +351,3 @@ class ThemeSet:
                 if pixSelected != None:
                     icon.addPixmap(pixSelected, QtGui.QIcon.Selected, QtGui.QIcon.On)
             return icon
-


### PR DESCRIPTION
There are still bugs related to setting game icons for freshly
downloaded previews, but it's a separate bug that will require a solid
refactor.

Fixes #804.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
