### PR TITLE
Improve client updater UX

### DIFF
--- a/res/client/update_settings.ui
+++ b/res/client/update_settings.ui
@@ -2,6 +2,17 @@
 <ui version="4.0">
  <class>Dialog</class>
  <widget class="QDialog" name="Dialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>328</width>
+    <height>353</height>
+   </rect>
+  </property>
   <property name="sizePolicy">
    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
     <horstretch>0</horstretch>
@@ -11,7 +22,13 @@
   <property name="windowTitle">
    <string>Update Settings</string>
   </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <property name="fieldGrowthPolicy">
     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
    </property>
@@ -55,6 +72,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="mouseTracking">
+      <bool>false</bool>
+     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Stable&lt;/span&gt; branch is the most conservative update setting. You will get less bugs, but new features and improvements will arrive slower.&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Stable + Pre-Release&lt;/span&gt; includes test releases of stable branch. Please select this update channel to help us test the stable branch. &lt;span style=&quot; font-weight:600;&quot;&gt;This is the recommended setting.&lt;br/&gt;Unstable&lt;/span&gt; is the most frequently updated channel. Use this to get new features, improvements and bugfixes first. Select this if you want to live on the edge.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
@@ -66,7 +86,30 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="cbDowngrade">
+     <property name="text">
+      <string>Show old releases</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Showing old releases lets you downgrade the client. This is not needed in most circumstances.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from PyQt5.QtCore import QUrl, QProcess
-from PyQt5.QtWidgets import QLabel
+from PyQt5.QtWidgets import QLabel, QMessageBox
 
 import config
 import connectivity
@@ -622,11 +622,14 @@ class ClientWindow(FormClass, BaseClass):
         self.lobby_connection.disconnect()
         self.chat.disconnect()
 
-    @QtCore.pyqtSlot(dict)
+    @QtCore.pyqtSlot(list)
     def update_checked(self, releases):
-        update_dialog = UpdateDialog(self)
-        update_dialog.setup(releases)
-        update_dialog.show()
+        if len(releases) > 0:
+            update_dialog = UpdateDialog(self)
+            update_dialog.setup(releases)
+            update_dialog.show()
+        else:
+            QMessageBox(self,"No updates found", "No client updates were found")
 
     @QtCore.pyqtSlot()
     def cleanup(self):

--- a/src/client/update_settings.py
+++ b/src/client/update_settings.py
@@ -13,6 +13,7 @@ FormClass, BaseClass = util.THEME.loadUiType("client/update_settings.ui")
 @with_logger
 class UpdateSettingsDialog(FormClass, BaseClass):
     updater_branch = Settings.persisted_property('updater/branch', type=str, default_value=UpdateBranch.Prerelease.name)
+    updater_downgrade = Settings.persisted_property('updater/downgrade', type=bool, default_value=False)
 
     def __init__(self, *args, **kwargs):
         BaseClass.__init__(self, *args, **kwargs)
@@ -23,6 +24,7 @@ class UpdateSettingsDialog(FormClass, BaseClass):
         self.setupUi(self)
 
         self.cbChannel.setCurrentIndex(UpdateBranch[self.updater_branch].value)
+        self.cbDowngrade.setChecked(self.updater_downgrade)
 
         self.buttonBox.accepted.connect(self.accepted)
         self.buttonBox.rejected.connect(lambda: self.close())
@@ -30,6 +32,7 @@ class UpdateSettingsDialog(FormClass, BaseClass):
     def accepted(self):
         branch = UpdateBranch(self.cbChannel.currentIndex())
         self.updater_branch = branch.name
+        self.updater_downgrade = self.cbDowngrade.isChecked()
         self.close()
 
 


### PR DESCRIPTION
* Never show same version client already has as update
* Don't call old versions "updates"
* Don't show old versions by default