### PR TITLE
Fix instructions in README in order for FAF to find faf-uid on Linux

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Note that the `faf-uid` smurf protection executable needs to run `xrandr`, `lspc
 
 Run the client:
 
-    cd ./faf-client && ../faf-client-venv/bin/python src/__main__.py
+    cd ./faf-client && PATH=$PATH:./lib ../faf-client-venv/bin/python src/__main__.py
 
 For more information see [the wiki](http://wiki.faforever.com/index.php?title=Setting_Up_FAF_Linux).
 


### PR DESCRIPTION
FAF expects faf-uid to be in PATH

Initial PR: N/A, this is a PR to the readme

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
