### PR TITLE
[WIP] Hotfix empty qturnsocket read

### DIFF
--- a/src/connectivity/qturnsocket.py
+++ b/src/connectivity/qturnsocket.py
@@ -157,4 +157,5 @@ class QTurnSocket(QUdpSocket):
         while self.hasPendingDatagrams():
             data, host, port = self.readDatagram(self.pendingDatagramSize())
             ipv4_address_string = QHostAddress(host.toIPv4Address()).toString() # host.toString() is expressed as IPv6 otherwise e.g. ::ffff:91.64.56.230
-            self.handle_data((ipv4_address_string, int(port)), data)
+            if data is not None:
+                self.handle_data((ipv4_address_string, int(port)), data)


### PR DESCRIPTION
qturnsocket apparently now returns empty reads when it didn't in the past. May be related to qt5 upgrade and/or Windows versions, since checking whether network data is pending is notoriously iffy and may not be reliable on all systems.

This hotfix ignores any None returns.

**WIP** because waiting on testers.

Fixes #846

Initial PR:

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [X] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
