### PR TITLE
fix friends on top

### DIFF
--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -132,8 +132,12 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
         else:
             self.insertTab(index, self.channels[name], name)
 
+    def sortChannels(self):
+        for channel in self.channels.values():
+            channel.sortChatters()
+
     def updateChannels(self):
-        for _, channel in self.channels.items():
+        for channel in self.channels.values():
             channel.updateChatters()
 
     def closeChannel(self, index):

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -87,7 +87,7 @@ class Channel(FormClass, BaseClass):
         self.name = name
         self.private = private
 
-        self.sortCall = ScheduledCall(self._sortChatters)
+        self.sortCall = ScheduledCall(self.sortChatters)
 
         if not self.private:
             # Properly and snugly snap all the columns
@@ -118,7 +118,7 @@ class Channel(FormClass, BaseClass):
         self.chatEdit.returnPressed.connect(self.sendLine)
         self.chatEdit.setChatters(self.chatters)
 
-    def _sortChatters(self):
+    def sortChatters(self):
         self.nickList.sortItems(Chatter.SORT_COLUMN)
 
     def joinChannel(self, index):

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -175,8 +175,8 @@ class Chatter(QtWidgets.QTableWidgetItem):
 
     def __lt__(self, other):
         """ Comparison operator used for item list sorting """
-        firstStatus = self.getUserRank(self)
-        secondStatus = self.getUserRank(other)
+        self_rank = self.get_user_rank(self)
+        other_rank = self.get_user_rank(other)
 
         if self._me.player is not None:
             if self.user.name == self._me.player.login:
@@ -185,8 +185,8 @@ class Chatter(QtWidgets.QTableWidgetItem):
                 return False
 
         # if not same rank sort
-        if firstStatus != secondStatus:
-            return firstStatus < secondStatus
+        if self_rank != other_rank:
+            return self_rank < other_rank
 
         # Default: Alphabetical
         return self.user.name.lower() < other.user.name.lower()
@@ -200,7 +200,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
         name = self.user.name
         return _id, name
 
-    def getUserRank(self, user):
+    def get_user_rank(self, user):
         # TODO: Add subdivision for admin?
         me = self._me
         _id, name = user._getIdName()
@@ -318,7 +318,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
                 else:
                     self.mapItem.setIcon(icon)
 
-                self.mapItem.setToolTip(mapname)
+                self.mapItem.setToolTip(game.mapdisplayname)
             else:
                 self.mapItem.setIcon(QtGui.QIcon())
                 self.mapItem.setToolTip("")

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -790,7 +790,9 @@ class ClientWindow(FormClass, BaseClass):
 
         self.gamelogs = self.actionSaveGamelogs.isChecked()
         self.player_colors.coloredNicknames = self.actionColoredNicknames.isChecked()
-        self.friendsontop = self.actionFriendsOnTop.isChecked()
+        if self.friendsontop != self.actionFriendsOnTop.isChecked():
+            self.friendsontop = self.actionFriendsOnTop.isChecked()
+            self.chat.sortChannels()
 
         self.saveChat()
 


### PR DESCRIPTION
add self.rank to reduce sorting call complexity/stack
add hack to update name to initiate sorting (which might have been the problem)
fix friends on top #813
remove unused self.status and useless self.rating

Well, kinda - just had a case where all irc were sorted in with the users on start, refaf and ok again, so something 'deeper' might be going wrong here. 
(if the initialisation doesn't go as planed: user - chatter - games, that could cause the above prbl., maybe the server update monday, will reduce or fix that prbl.)
