### PR TITLE
Remove trueskill dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ pytest
 pytest-cov
 pytest-mock
 pytest-qt
-trueskill
 semantic_version
 idna

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -2,7 +2,6 @@ from . import version
 import os
 import sys
 import logging
-import trueskill
 import fafpath
 import traceback
 from PyQt5 import QtCore
@@ -13,8 +12,6 @@ if sys.platform == 'win32':
     import win32con
     import win32security
     from . import admin
-
-trueskill.setup(mu=1500, sigma=500, beta=250, tau=5, draw_probability=0.10)
 
 _settings = QtCore.QSettings(QtCore.QSettings.IniFormat, QtCore.QSettings.UserScope, "ForgedAllianceForever", "FA Lobby")
 _unpersisted_settings = {}


### PR DESCRIPTION
We don't use trueskill right now, and the client will be easier to setup
on Ubuntu without it.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
