### PR TITLE
Set focus policy of games tab elements to no focus

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
    - Game and chat tabs converted from QListWidgets to QListViews based on a
      single model, ensuring proper game tracking, filtering and sorting
    - Many small refactors necessary to introduce the model
+ * Pressing spacebar on games tab will no longer start ladder search (#860, #861)
 
 Contributors:
  - Wesmania

--- a/res/games/games.ui
+++ b/res/games/games.ui
@@ -369,6 +369,9 @@
              <height>25</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="acceptDrops">
             <bool>false</bool>
            </property>
@@ -545,10 +548,16 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
           </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="hideGamesWithPw">
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="text">
             <string>Hide Private Games</string>
            </property>


### PR DESCRIPTION
This way pressing space won't accidentally start ladder search or do
other nefarious things. Fixes #860.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
