### PR TITLE
Add a map icon column to the chat widget

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,11 +13,13 @@
    - Many small refactors necessary to introduce the model
  * Pressing spacebar on games tab will no longer start ladder search (#860, #861)
  * Notification when a game is full
+ * Added new map preview icon in chat. Toggle in the chat settings.
 
 Contributors:
  - Wesmania
  - Grothe
  - Surtsan
+ - IceDreamer
 
 0.16.0
 ====

--- a/res/chat/channel.ui
+++ b/res/chat/channel.ui
@@ -264,7 +264,7 @@ p, li { white-space: pre-wrap; }
           <bool>false</bool>
          </property>
          <property name="columnCount">
-          <number>4</number>
+          <number>5</number>
          </property>
          <attribute name="horizontalHeaderVisible">
           <bool>false</bool>

--- a/res/chat/formatters/nicklist_columns.json
+++ b/res/chat/formatters/nicklist_columns.json
@@ -1,1 +1,1 @@
-{"RANK" : 32, "AVATAR" : 46, "NAME" : "*", "STATUS" : 22}
+{"RANK" : 32, "AVATAR" : 46, "NAME" : "*", "STATUS" : 22, "MAP" : 26}

--- a/res/client/client.ui
+++ b/res/client/client.ui
@@ -286,6 +286,7 @@
      <addaction name="actionSetOpenGames"/>
      <addaction name="actionSetLiveReplays"/>
      <addaction name="actionSetSoundEffects"/>
+     <addaction name="actionSetChatMaps"/>
      <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuNotifications">
@@ -492,6 +493,14 @@
    </property>
    <property name="text">
     <string>&amp;Joins / Parts</string>
+   </property>
+  </action>
+  <action name="actionSetChatMaps">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Map icons in chat</string>
    </property>
   </action>
   <action name="actionSetOpenGames">

--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -132,6 +132,10 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
         else:
             self.insertTab(index, self.channels[name], name)
 
+    def updateChannels(self):
+        for _, channel in self.channels.items():
+            channel.updateChatters()
+
     def closeChannel(self, index):
         """
         Closes a channel tab.

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -376,6 +376,15 @@ class Channel(FormClass, BaseClass):
             chatter = self.nickList.item(item.row(), Chatter.SORT_COLUMN)
             chatter.pressed(item)
 
+    def updateChatters(self):
+        """
+        Triggers all chatters to update their status. Called when toggling map icon display in settings
+        """
+        for _, chatter in self.chatters.items():
+            chatter.update()
+
+        self.resizeMapColumn()
+
     def resizeMapColumn(self):
         if util.settings.value("chat/chatmaps", False):
             self.nickList.horizontalHeader().resizeSection(Chatter.MAP_COLUMN, Formatters.NICKLIST_COLUMNS['MAP'])

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -100,6 +100,9 @@ class Channel(FormClass, BaseClass):
             self.nickList.horizontalHeader().setSectionResizeMode(Chatter.STATUS_COLUMN, QtWidgets.QHeaderView.Fixed)
             self.nickList.horizontalHeader().resizeSection(Chatter.STATUS_COLUMN, Formatters.NICKLIST_COLUMNS['STATUS'])
 
+            self.nickList.horizontalHeader().setSectionResizeMode(Chatter.MAP_COLUMN, QtWidgets.QHeaderView.Fixed)
+            self.resizeMapColumn()  # The map column can be toggled. Make sure it respects the settings
+
             self.nickList.horizontalHeader().setSectionResizeMode(Chatter.SORT_COLUMN, QtWidgets.QHeaderView.Stretch)
 
             self.nickList.itemDoubleClicked.connect(self.nickDoubleClicked)
@@ -372,6 +375,12 @@ class Channel(FormClass, BaseClass):
             # Look up the associated chatter object
             chatter = self.nickList.item(item.row(), Chatter.SORT_COLUMN)
             chatter.pressed(item)
+
+    def resizeMapColumn(self):
+        if util.settings.value("chat/chatmaps", False):
+            self.nickList.horizontalHeader().resizeSection(Chatter.MAP_COLUMN, Formatters.NICKLIST_COLUMNS['MAP'])
+        else:
+            self.nickList.horizontalHeader().resizeSection(Chatter.MAP_COLUMN, 0)
 
     def addChatter(self, chatter, join=False):
         """

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -297,6 +297,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
 
     def updateGame(self):
         # Status icon handling
+
         game = self.user_game
         player = self.user_player
         if game is not None and not game.closed():
@@ -307,6 +308,9 @@ class Chatter(QtWidgets.QTableWidgetItem):
             elif game.state == GameState.PLAYING:
                 self.statusItem.setIcon(util.THEME.icon("chat/status/playing.png"))
                 self.statusItem.setToolTip("Playing Game<br/>"+url.toString())
+
+            # We're in game, show the map if toggled on
+            if util.settings.value("chat/chatmaps", False):
                 mapname = game.mapname
                 icon = maps.preview(mapname)
                 if not icon:
@@ -315,6 +319,9 @@ class Chatter(QtWidgets.QTableWidgetItem):
                     self.mapItem.setIcon(icon)
 
                 self.mapItem.setToolTip(mapname)
+            else:
+                self.mapItem.setIcon(QtGui.QIcon())
+                self.mapItem.setToolTip("")
         else:
             self.statusItem.setIcon(QtGui.QIcon())
             self.statusItem.setToolTip("Idle")

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -4,7 +4,10 @@ from PyQt5.QtNetwork import QNetworkRequest
 from chat._avatarWidget import AvatarWidget
 import time
 import urllib.request, urllib.error, urllib.parse
+
 from fa.replay import replay
+from fa import maps
+
 import util
 import client
 from config import Settings
@@ -23,6 +26,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
     AVATAR_COLUMN = 1
     RANK_COLUMN = 0
     STATUS_COLUMN = 3
+    MAP_COLUMN = 4
 
     RANK_ELEVATION = 0
     RANK_FRIEND = 1
@@ -59,6 +63,10 @@ class Chatter(QtWidgets.QTableWidgetItem):
         self.statusItem.setFlags(QtCore.Qt.ItemIsEnabled)
         self.statusItem.setTextAlignment(QtCore.Qt.AlignHCenter)
 
+        self.mapItem = QtWidgets.QTableWidgetItem()
+        self.mapItem.setFlags(QtCore.Qt.ItemIsEnabled)
+        self.mapItem.setTextAlignment(QtCore.Qt.AlignHCenter)
+
         self._user = None
         self._user_player = None
         self._user_game = None
@@ -73,6 +81,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
         self.parent.setItem(self.row(), Chatter.RANK_COLUMN, self.rankItem)
         self.parent.setItem(self.row(), Chatter.AVATAR_COLUMN, self.avatarItem)
         self.parent.setItem(self.row(), Chatter.STATUS_COLUMN, self.statusItem)
+        self.parent.setItem(self.row(), Chatter.MAP_COLUMN, self.mapItem)
 
     @property
     def user(self):
@@ -298,6 +307,14 @@ class Chatter(QtWidgets.QTableWidgetItem):
             elif game.state == GameState.PLAYING:
                 self.statusItem.setIcon(util.THEME.icon("chat/status/playing.png"))
                 self.statusItem.setToolTip("Playing Game<br/>"+url.toString())
+                mapname = game.mapname
+                icon = maps.preview(mapname)
+                if not icon:
+                    self.chat_widget.client.downloader.downloadMapPreview(mapname, self.mapItem)  # Calls setIcon
+                else:
+                    self.mapItem.setIcon(icon)
+
+                self.mapItem.setToolTip(mapname)
         else:
             self.statusItem.setIcon(QtGui.QIcon())
             self.statusItem.setToolTip("Idle")

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -768,6 +768,7 @@ class ClientWindow(FormClass, BaseClass):
         self.actionSetOpenGames.triggered.connect(self.updateOptions)
         self.actionSetJoinsParts.triggered.connect(self.updateOptions)
         self.actionSetLiveReplays.triggered.connect(self.updateOptions)
+        self.actionSetChatMaps.triggered.connect(self.toggleChatMaps)
         self.actionSaveGamelogs.toggled.connect(self.on_actionSavegamelogs_toggled)
         self.actionSaveGamelogs.setChecked(self.gamelogs)
         self.actionColoredNicknames.triggered.connect(self.updateOptions)
@@ -783,6 +784,7 @@ class ClientWindow(FormClass, BaseClass):
         self.soundeffects = self.actionSetSoundEffects.isChecked()
         self.game_announcer.announce_games = self.actionSetOpenGames.isChecked()
         self.joinsparts = self.actionSetJoinsParts.isChecked()
+        self.chatmaps = self.actionSetChatMaps.isChecked()
         self.game_announcer.announce_replays = self.actionSetLiveReplays.isChecked()
 
         self.gamelogs = self.actionSaveGamelogs.isChecked()
@@ -790,6 +792,10 @@ class ClientWindow(FormClass, BaseClass):
         self.friendsontop = self.actionFriendsOnTop.isChecked()
 
         self.saveChat()
+
+    def toggleChatMaps(self):
+        self.updateOptions()
+        self.chat.updateChannels()
 
     @QtCore.pyqtSlot()
     def switchPath(self):
@@ -868,6 +874,7 @@ class ClientWindow(FormClass, BaseClass):
         util.settings.setValue("livereplays", self.game_announcer.announce_replays)
         util.settings.setValue("opengames", self.game_announcer.announce_games)
         util.settings.setValue("joinsparts", self.joinsparts)
+        util.settings.setValue("chatmaps", self.chatmaps)
         util.settings.setValue("coloredNicknames", self.player_colors.coloredNicknames)
         util.settings.setValue("friendsontop", self.friendsontop)
         util.settings.endGroup()
@@ -890,6 +897,7 @@ class ClientWindow(FormClass, BaseClass):
             self.soundeffects = (util.settings.value("soundeffects", "true") == "true")
             self.game_announcer.announce_games = (util.settings.value("opengames", "true") == "true")
             self.joinsparts = (util.settings.value("joinsparts", "false") == "true")
+            self.chatmaps = (util.settings.value("chatmaps", "false") == "true")
             self.game_announcer.announce_replays = (util.settings.value("livereplays", "true") == "true")
             self.player_colors.coloredNicknames = (util.settings.value("coloredNicknames", "false") == "true")
             self.friendsontop = (util.settings.value("friendsontop", "false") == "true")
@@ -901,6 +909,7 @@ class ClientWindow(FormClass, BaseClass):
             self.actionSetLiveReplays.setChecked(self.game_announcer.announce_replays)
             self.actionSetOpenGames.setChecked(self.game_announcer.announce_games)
             self.actionSetJoinsParts.setChecked(self.joinsparts)
+            self.actionSetChatMaps.setChecked(self.chatmaps)
         except:
             pass
 

--- a/src/coop/coopmapitem.py
+++ b/src/coop/coopmapitem.py
@@ -83,7 +83,7 @@ class CoopMapItem(QtWidgets.QTreeWidgetItem):
 
 #        self.icon = maps.preview(self.mapname)
 #        if not self.icon:
-#            self.client.downloader.downloadMap(self.mapname, self, True)
+#            self.client.downloader.downloadMapPreview(self.mapname, self, True)
 #            self.icon = util.THEME.icon("games/unknown_map.png")
 #        self.setIcon(0, self.icon)
 

--- a/src/downloadManager/__init__.py
+++ b/src/downloadManager/__init__.py
@@ -175,7 +175,7 @@ class downloadManager(QtCore.QObject):
         img.open(QtCore.QIODevice.WriteOnly)
         return img, imgpath
 
-    def downloadMap(self, name, requester, item=False):
+    def downloadMapPreview(self, name, requester, item=False):
         """
         Downloads a preview image from the web for the given map name
         """

--- a/src/games/gameitem.py
+++ b/src/games/gameitem.py
@@ -29,7 +29,7 @@ class GameView(QtCore.QObject):
 
     def download_map_preview(self, mapname):
         cb = IconCallback(mapname, self._map_preview_downloaded)
-        self._dler.downloadMap(mapname, cb)
+        self._dler.downloadMapPreview(mapname, cb)
 
     # TODO make it a utility function?
     def _model_items(self):

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -142,7 +142,7 @@ class LiveReplaysWidgetHandler(object):
         icon = fa.maps.preview(game.mapname)
         item.setToolTip(0, fa.maps.getDisplayName(game.mapname))
         if not icon:
-            self.client.downloader.downloadMap(game.mapname, item, True)
+            self.client.downloader.downloadMapPreview(game.mapname, item, True)
             icon = util.THEME.icon("games/unknown_map.png")
 
         item.setText(0, time.strftime("%Y-%m-%d  -  %H:%M", time.localtime(launched_at)))
@@ -321,7 +321,7 @@ class LocalReplaysWidgetHandler(object):
                         if icon:
                             item.setIcon(0, icon)
                         else:
-                            client.instance.downloader.downloadMap(item.info['mapname'], item, True)
+                            client.instance.downloader.downloadMapPreview(item.info['mapname'], item, True)
                             item.setIcon(0, util.THEME.icon("games/unknown_map.png"))
                         item.setToolTip(0, fa.maps.getDisplayName(item.info['mapname']))
                         item.setText(0, game_hour)

--- a/src/replays/replayitem.py
+++ b/src/replays/replayitem.py
@@ -144,7 +144,7 @@ class ReplayItem(QtWidgets.QTreeWidgetItem):
       
         self.icon = maps.preview(self.mapname)
         if not self.icon:
-            self.client.downloader.downloadMap(self.mapname, self, True)
+            self.client.downloader.downloadMapPreview(self.mapname, self, True)
             self.icon = util.THEME.icon("games/unknown_map.png")
 
         if self.mod in mods:

--- a/src/tutorials/tutorialitem.py
+++ b/src/tutorials/tutorialitem.py
@@ -93,7 +93,7 @@ class TutorialItem(QtWidgets.QListWidgetItem):
             icon = maps.preview(self.mapname)
             if not icon:
                 icon = util.THEME.icon("games/unknown_map.png")
-                self.client.downloader.downloadMap(self.mapname, self)
+                self.client.downloader.downloadMapPreview(self.mapname, self)
 
             self.setIcon(icon)
 


### PR DESCRIPTION
Rebased and adapted from #331.
This adds a new column which shows a map preview in the player list of the chat tab. There is a settings menu toggle for it, and the chat resizes itself to fit

- [X] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [X] Code is split into logical commits
- [ ] Code has tests
- [ ] Add changelog entry
