### PR TITLE
Pin cx_freeze version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - "%PYTHON%\\Scripts\\pip install https://github.com/FAForever/python-wheels/releases/download/2.0.0/pywin32-221-%PYWHEEL_INFIX%-%PYWHEEL_INFIX%m-win32.whl"
   - "%PYTHON%\\Scripts\\pip install wheel"
   - "%PYTHON%\\Scripts\\pip install pytest"
-  - "%PYTHON%\\Scripts\\pip install cx_Freeze"
+  - "%PYTHON%\\Scripts\\pip install cx_Freeze==5.0.2"
   - "%PYTHON%\\Scripts\\pip install -r requirements.txt --trusted-host content.faforever.com"
   # copy required dlls for packaging in setup.py
   - "xcopy %PYTHON%\\lib\\site-packages\\PyQt5\\Qt\\plugins\\imageformats .\\imageformats /I"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cx_Freeze
+cx_Freeze==5.0.2
 ipaddress
 pathlib
 pyqt5


### PR DESCRIPTION
It seems cx_freeze 5.1 merged in a change that changed the build process: https://github.com/anthony-tuininga/cx_Freeze/pull/286. Let's pin it for now and make an upstream issue.
