### PR TITLE
fix #890 chatter map icon

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@
    - Many small refactors necessary to introduce the model
  * Pressing spacebar on games tab will no longer start ladder search (#860, #861)
  * Notification when a game is full
- * Added new map preview icon in chat. Toggle in the chat settings.
+ * Added map preview icon in chat. Toggle in the chat settings. (#870, #891)
  * Add menu Link to ladder map pool in forum (#882)
 
 Contributors:

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -297,7 +297,6 @@ class Chatter(QtWidgets.QTableWidgetItem):
 
     def updateGame(self):
         # Status icon handling
-
         game = self.user_game
         player = self.user_player
         if game is not None and not game.closed():
@@ -312,7 +311,11 @@ class Chatter(QtWidgets.QTableWidgetItem):
             self.statusItem.setIcon(QtGui.QIcon())
             self.statusItem.setToolTip("Idle")
 
+        self.updateMap()
+
+    def updateMap(self):
         # Map icon handling - if we're in game, show the map if toggled on
+        game = self.user_game
         if game is not None and not game.closed() and util.settings.value("chat/chatmaps", False):
             mapname = game.mapname
             icon = maps.preview(mapname)
@@ -325,8 +328,6 @@ class Chatter(QtWidgets.QTableWidgetItem):
         else:
             self.mapItem.setIcon(QtGui.QIcon())
             self.mapItem.setToolTip("")
-
-        self._verifySortOrder()
 
     def update(self):
         self.updateUser()

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -308,23 +308,23 @@ class Chatter(QtWidgets.QTableWidgetItem):
             elif game.state == GameState.PLAYING:
                 self.statusItem.setIcon(util.THEME.icon("chat/status/playing.png"))
                 self.statusItem.setToolTip("Playing Game<br/>"+url.toString())
-
-            # We're in game, show the map if toggled on
-            if util.settings.value("chat/chatmaps", False):
-                mapname = game.mapname
-                icon = maps.preview(mapname)
-                if not icon:
-                    self.chat_widget.client.downloader.downloadMapPreview(mapname, self.mapItem)  # Calls setIcon
-                else:
-                    self.mapItem.setIcon(icon)
-
-                self.mapItem.setToolTip(game.mapdisplayname)
-            else:
-                self.mapItem.setIcon(QtGui.QIcon())
-                self.mapItem.setToolTip("")
         else:
             self.statusItem.setIcon(QtGui.QIcon())
             self.statusItem.setToolTip("Idle")
+
+        # Map icon handling - if we're in game, show the map if toggled on
+        if game is not None and not game.closed() and util.settings.value("chat/chatmaps", False):
+            mapname = game.mapname
+            icon = maps.preview(mapname)
+            if not icon:
+                self.chat_widget.client.downloader.downloadMapPreview(mapname, self.mapItem)  # Calls setIcon
+            else:
+                self.mapItem.setIcon(icon)
+
+            self.mapItem.setToolTip(game.mapdisplayname)
+        else:
+            self.mapItem.setIcon(QtGui.QIcon())
+            self.mapItem.setToolTip("")
 
         self._verifySortOrder()
 


### PR DESCRIPTION
move map handling outside of status handling for clarity
fix case after game or lobby end still showing map icon
