### PR TITLE
make python functions lower case (in chat) fix #908

### DIFF
--- a/src/chat/_avatarWidget.py
+++ b/src/chat/_avatarWidget.py
@@ -22,25 +22,25 @@ class PlayerAvatar(QtWidgets.QDialog):
         self.removeButton = QtWidgets.QPushButton("&Remove users")
         self.grid.addWidget(self.removeButton, 1, 0)
 
-        self.removeButton.clicked.connect(self.removeThem)
+        self.removeButton.clicked.connect(self.remove_them)
 
         self.setWindowTitle("Users using this avatar")
         self.resize(480, 320)         
 
-    def processList(self, users, idavatar):
+    def process_list(self, users, idavatar):
         self.checkBox = {}
         self.users = users
         self.idavatar = idavatar
-        self.userlist = self.createUserSelection()
+        self.userlist = self.create_user_selection()
         self.grid.addWidget(self.userlist, 0, 0)
 
-    def removeThem(self):
+    def remove_them(self):
         for user in self.checkBox :
             if self.checkBox[user].checkState() == 2:
                 self.parent.lobby_connection.send(dict(command="admin", action="remove_avatar", iduser=user, idavatar=self.idavatar))
         self.close()
 
-    def createUserSelection(self):
+    def create_user_selection(self):
         groupBox = QtWidgets.QGroupBox("Select the users you want to remove this avatar :")
         vbox = QtWidgets.QVBoxLayout()
 
@@ -65,24 +65,24 @@ class AvatarWidget(QtWidgets.QDialog):
 
         self.setStyleSheet(self.parent.styleSheet())
         self.setWindowTitle("Avatar manager")
-        
-        self.group_layout = QtWidgets.QVBoxLayout(self)
-        self.listAvatars = QtWidgets.QListWidget()
-         
-        self.listAvatars.setWrapping(1)
-        self.listAvatars.setSpacing(5)
-        self.listAvatars.setResizeMode(1)
 
-        self.group_layout.addWidget(self.listAvatars)
+        self.groupLayout = QtWidgets.QVBoxLayout(self)
+        self.avatarList = QtWidgets.QListWidget()
+
+        self.avatarList.setWrapping(1)
+        self.avatarList.setSpacing(5)
+        self.avatarList.setResizeMode(1)
+
+        self.groupLayout.addWidget(self.avatarList)
 
         if not self.personal:
             self.addAvatarButton = QtWidgets.QPushButton("Add/Edit avatar")
-            self.addAvatarButton.clicked.connect(self.addAvatar)
-            self.group_layout.addWidget(self.addAvatarButton)
+            self.addAvatarButton.clicked.connect(self.add_avatar)
+            self.groupLayout.addWidget(self.addAvatarButton)
 
         self.item = []
-        self.parent.lobby_info.avatarList.connect(self.avatarList)
-        self.parent.lobby_info.playerAvatarList.connect(self.doPlayerAvatarList)
+        self.parent.lobby_info.avatarList.connect(self.avatar_list)
+        self.parent.lobby_info.playerAvatarList.connect(self.do_player_avatar_list)
 
         self.playerList = PlayerAvatar(parent=self.parent)
 
@@ -94,7 +94,7 @@ class AvatarWidget(QtWidgets.QDialog):
     def showEvent(self, event):
         self.parent.requestAvatars(self.personal)
 
-    def addAvatar(self):
+    def add_avatar(self):
 
         options = QtWidgets.QFileDialog.Options()
         options |= QtWidgets.QFileDialog.DontUseNativeDialog
@@ -122,7 +122,7 @@ class AvatarWidget(QtWidgets.QDialog):
             else:
                 QtWidgets.QMessageBox.warning(self, "Bad image", "The image must be in png, format is 40x20 !")
 
-    def finishRequest(self, reply):
+    def finish_request(self, reply):
 
         if reply.url().toString() in self.avatars:
             img = QtGui.QImage()
@@ -152,15 +152,15 @@ class AvatarWidget(QtWidgets.QDialog):
                 self.parent.lobby_connection.send(dict(command="admin", action="add_avatar", user=self.user, avatar=val))
                 self.close()
 
-    def doPlayerAvatarList(self, message):
+    def do_player_avatar_list(self, message):
         self.playerList = PlayerAvatar(parent=self.parent)
         player_avatar_list = message["player_avatar_list"]
         idavatar = message["avatar_id"]
-        self.playerList.processList(player_avatar_list, idavatar)
+        self.playerList.process_list(player_avatar_list, idavatar)
         self.playerList.show()
 
-    def avatarList(self, avatar_list):
-        self.listAvatars.clear()
+    def avatar_list(self, avatar_list):
+        self.avatarList.clear()
         button = QtWidgets.QPushButton()
         self.avatars["None"] = button
 
@@ -169,8 +169,8 @@ class AvatarWidget(QtWidgets.QDialog):
 
         self.item.append(item)
 
-        self.listAvatars.addItem(item)
-        self.listAvatars.setItemWidget(item, button)
+        self.avatarList.addItem(item)
+        self.avatarList.setItemWidget(item, button)
 
         button.clicked.connect(self.clicked)
 
@@ -185,17 +185,17 @@ class AvatarWidget(QtWidgets.QDialog):
             item.setSizeHint(QtCore.QSize(40, 20))
             self.item.append(item)
 
-            self.listAvatars.addItem(item)
+            self.avatarList.addItem(item)
 
             button.setToolTip(avatar["tooltip"])
             url = QtCore.QUrl(avatar["url"])            
             self.avatars[avatar["url"]] = button
 
-            self.listAvatars.setItemWidget(item, self.avatars[avatar["url"]])
+            self.avatarList.setItemWidget(item, self.avatars[avatar["url"]])
 
             if not avatarPix:
                 self.nams[url] = QNetworkAccessManager(button)
-                self.nams[url].finished.connect(self.finishRequest)
+                self.nams[url].finished.connect(self.finish_request)
                 self.nams[url].get(QNetworkRequest(url))
             else:
                 self.avatars[avatar["url"]].setIcon(QtGui.QIcon(avatarPix))
@@ -203,5 +203,5 @@ class AvatarWidget(QtWidgets.QDialog):
 
     def cleaning(self):
         if self != self.parent.avatarAdmin:
-            self.parent.lobby_info.avatarList.disconnect(self.avatarList)
-            self.parent.lobby_info.playerAvatarList.disconnect(self.doPlayerAvatarList)
+            self.parent.lobby_info.avatarList.disconnect(self.avatar_list)
+            self.parent.lobby_info.playerAvatarList.disconnect(self.do_player_avatar_list)

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -48,15 +48,15 @@ class ScheduledCall(QtCore.QObject):
         QtCore.QObject.__init__(self)
         self._fn = fn
         self._called = False
-        self._call.connect(self._runCall, QtCore.Qt.QueuedConnection)
+        self._call.connect(self._run_call, QtCore.Qt.QueuedConnection)
 
-    def scheduleCall(self):
+    def schedule_call(self):
         if self._called:
             return
         self._called = True
         self._call.emit()
 
-    def _runCall(self):
+    def _run_call(self):
         self._called = False
         self._fn()
 
@@ -76,7 +76,7 @@ class Channel(FormClass, BaseClass):
         self.items = {}
         self._chatterset = chatterset
         self._me = me
-        chatterset.userRemoved.connect(self._checkUserQuit)
+        chatterset.userRemoved.connect(self._check_user_quit)
 
         self.last_timestamp = None
 
@@ -86,7 +86,7 @@ class Channel(FormClass, BaseClass):
         self.blinked = False
 
         # Table width of each chatter's name cell...
-        self.maxChatterWidth = 100  # TODO: This might / should auto-adapt
+        self.max_chatter_width = 100  # TODO: This might / should auto-adapt
 
         # count the number of line currently in the chat
         self.lines = 0
@@ -95,7 +95,7 @@ class Channel(FormClass, BaseClass):
         self.name = name
         self.private = private
 
-        self.sortCall = ScheduledCall(self.sortChatters)
+        self.sort_call = ScheduledCall(self.sort_chatters)
 
         if not self.private:
             # Properly and snugly snap all the columns
@@ -109,31 +109,31 @@ class Channel(FormClass, BaseClass):
             self.nickList.horizontalHeader().resizeSection(Chatter.STATUS_COLUMN, Formatters.NICKLIST_COLUMNS['STATUS'])
 
             self.nickList.horizontalHeader().setSectionResizeMode(Chatter.MAP_COLUMN, QtWidgets.QHeaderView.Fixed)
-            self.resizeMapColumn()  # The map column can be toggled. Make sure it respects the settings
+            self.resize_map_column()  # The map column can be toggled. Make sure it respects the settings
 
             self.nickList.horizontalHeader().setSectionResizeMode(Chatter.SORT_COLUMN, QtWidgets.QHeaderView.Stretch)
 
-            self.nickList.itemDoubleClicked.connect(self.nickDoubleClicked)
-            self.nickList.itemPressed.connect(self.nickPressed)
+            self.nickList.itemDoubleClicked.connect(self.nick_double_clicked)
+            self.nickList.itemPressed.connect(self.nick_pressed)
 
-            self.nickFilter.textChanged.connect(self.filterNicks)
+            self.nickFilter.textChanged.connect(self.filter_nicks)
 
         else:
             self.nickFrame.hide()
             self.announceLine.hide()
 
-        self.chatArea.anchorClicked.connect(self.openUrl)
-        self.chatEdit.returnPressed.connect(self.sendLine)
-        self.chatEdit.setChatters(self.chatters)
+        self.chatArea.anchorClicked.connect(self.open_url)
+        self.chatEdit.returnPressed.connect(self.send_line)
+        self.chatEdit.set_chatters(self.chatters)
 
-    def sortChatters(self):
+    def sort_chatters(self):
         self.nickList.sortItems(Chatter.SORT_COLUMN)
 
-    def joinChannel(self, index):
+    def join_channel(self, index):
         """ join another channel """
         channel = self.channelsComboBox.itemText(index)
         if channel.startswith('#'):
-            self.chat_widget.autoJoin([channel])
+            self.chat_widget.auto_join([channel])
 
     def keyReleaseEvent(self, keyevent):
         """
@@ -144,14 +144,14 @@ class Channel(FormClass, BaseClass):
 
     def resizeEvent(self, size):
         BaseClass.resizeEvent(self, size)
-        self.setTextWidth()
+        self.set_text_width()
 
-    def setTextWidth(self):
+    def set_text_width(self):
         self.chatArea.setLineWrapColumnOrWidth(self.chatArea.size().width() - 20)  # Hardcoded, but seems to be enough (tabstop was a bit large)
 
     def showEvent(self, event):
-        self.stopBlink()
-        self.setTextWidth()
+        self.stop_blink()
+        self.set_text_width()
         return BaseClass.showEvent(self, event)
 
     @QtCore.pyqtSlot()
@@ -161,16 +161,16 @@ class Channel(FormClass, BaseClass):
             self.last_timestamp = 0
 
     @QtCore.pyqtSlot()
-    def filterNicks(self):
+    def filter_nicks(self):
         for chatter in self.chatters.values():
-            chatter.setVisible(chatter.isFiltered(self.nickFilter.text().lower()))
+            chatter.set_visible(chatter.is_filtered(self.nickFilter.text().lower()))
 
-    def updateUserCount(self):
+    def update_user_count(self):
         count = len(self.chatters)
         self.nickFilter.setPlaceholderText(str(count) + " users... (type to filter)")
 
         if self.nickFilter.text():
-            self.filterNicks()
+            self.filter_nicks()
 
     @QtCore.pyqtSlot()
     def blink(self):
@@ -182,29 +182,29 @@ class Channel(FormClass, BaseClass):
             self.chat_widget.tabBar().setTabText(self.chat_widget.indexOf(self), "")
 
     @QtCore.pyqtSlot()
-    def stopBlink(self):
+    def stop_blink(self):
         self.blinker.stop()
         self.chat_widget.tabBar().setTabText(self.chat_widget.indexOf(self), self.name)
 
     @QtCore.pyqtSlot()
-    def startBlink(self):
+    def start_blink(self):
         self.blinker.start(QUERY_BLINK_SPEED)
 
     @QtCore.pyqtSlot()
-    def pingWindow(self):
+    def ping_window(self):
         QtWidgets.QApplication.alert(self.chat_widget.client)
 
         if not self.isVisible() or QtWidgets.QApplication.activeWindow() != self.chat_widget.client:
-            if self.oneMinuteOrOlder():
+            if self.one_minute_or_older():
                 if self.chat_widget.client.soundeffects:
                     util.THEME.sound("chat/sfx/query.wav")
 
         if not self.isVisible():
             if not self.blinker.isActive() and not self == self.chat_widget.currentWidget():
-                self.startBlink()
+                self.start_blink()
 
     @QtCore.pyqtSlot(QtCore.QUrl)
-    def openUrl(self, url):
+    def open_url(self, url):
         logger.debug("Clicked on URL: " + url.toString())
         if url.scheme() == "faflive":
             replay(url)
@@ -213,7 +213,7 @@ class Channel(FormClass, BaseClass):
         else:
             QtGui.QDesktopServices.openUrl(url)
 
-    def printAnnouncement(self, text, color, size, scroll_forced = True):
+    def print_announcement(self, text, color, size, scroll_forced=True):
         # scroll if close to the last line of the log
         scroll_current = self.chatArea.verticalScrollBar().value()
         scroll_needed = scroll_forced or ((self.chatArea.verticalScrollBar().maximum() - scroll_current) < 20)
@@ -231,7 +231,7 @@ class Channel(FormClass, BaseClass):
         else:
             self.chatArea.verticalScrollBar().setValue(scroll_current)
 
-    def printLine(self, chname, text, scroll_forced=False, formatter=Formatters.FORMATTER_MESSAGE):
+    def print_line(self, chname, text, scroll_forced=False, formatter=Formatters.FORMATTER_MESSAGE):
         if self.lines > CHAT_TEXT_LIMIT:
             cursor = self.chatArea.textCursor()
             cursor.movePosition(QtGui.QTextCursor.Start)
@@ -256,7 +256,7 @@ class Channel(FormClass, BaseClass):
         is_quit_msg = formatter is Formatters.FORMATTER_RAW and text == "quit."
         private_msg = self.private and not is_quit_msg
         if (mentioned or private_msg) and sender_is_not_me:
-            self.pingWindow()
+            self.ping_window()
 
         avatar = None
         avatarTip = ""
@@ -295,7 +295,7 @@ class Channel(FormClass, BaseClass):
             formatter = Formatters.convert_to_no_avatar(formatter)
 
         line = formatter.format(time=self.timestamp(), avatar=avatar, avatarTip=avatarTip, name=displayName,
-                                color=color, width=self.maxChatterWidth, text=util.irc_escape(text, self.chat_widget.a_style))
+                                color=color, width=self.max_chatter_width, text=util.irc_escape(text, self.chat_widget.a_style))
         self.chatArea.insertHtml(line)
         self.lines += 1
 
@@ -322,23 +322,23 @@ class Channel(FormClass, BaseClass):
             return False
         return True
 
-    def printMsg(self, chname, text, scroll_forced=False):
+    def print_msg(self, chname, text, scroll_forced=False):
         if self._chname_has_avatar(chname) and not self.private:
             fmt = Formatters.FORMATTER_MESSAGE_AVATAR
         else:
             fmt = Formatters.FORMATTER_MESSAGE
-        self.printLine(chname, text, scroll_forced, fmt)
+        self.print_line(chname, text, scroll_forced, fmt)
 
-    def printAction(self, chname, text, scroll_forced=False, server_action=False):
+    def print_action(self, chname, text, scroll_forced=False, server_action=False):
         if server_action:
             fmt = Formatters.FORMATTER_RAW
         elif self._chname_has_avatar(chname) and not self.private:
             fmt = Formatters.FORMATTER_ACTION_AVATAR
         else:
             fmt = Formatters.FORMATTER_ACTION
-        self.printLine(chname, text, scroll_forced, fmt)
+        self.print_line(chname, text, scroll_forced, fmt)
 
-    def printRaw(self, chname, text, scroll_forced=False):
+    def print_raw(self, chname, text, scroll_forced=False):
         """
         Print an raw message in the chatArea of the channel
         """
@@ -352,7 +352,7 @@ class Channel(FormClass, BaseClass):
 
         # Play a ping sound
         if self.private and chname != self.chat_widget.client.login:
-            self.pingWindow()
+            self.ping_window()
 
         # scroll if close to the last line of the log
         scroll_current = self.chatArea.verticalScrollBar().value()
@@ -363,7 +363,7 @@ class Channel(FormClass, BaseClass):
         self.chatArea.setTextCursor(cursor)
 
         formatter = Formatters.FORMATTER_RAW
-        line = formatter.format(time=self.timestamp(), name=chname, color=color, width=self.maxChatterWidth, text=text)
+        line = formatter.format(time=self.timestamp(), name=chname, color=color, width=self.max_chatter_width, text=text)
         self.chatArea.insertHtml(line)
 
         if scroll_needed:
@@ -380,38 +380,38 @@ class Channel(FormClass, BaseClass):
         else:
             return ""
 
-    def oneMinuteOrOlder(self):
+    def one_minute_or_older(self):
         timestamp = time.strftime("%H:%M")
         return self.last_timestamp != timestamp
 
     @QtCore.pyqtSlot(QtWidgets.QTableWidgetItem)
-    def nickDoubleClicked(self, item):
+    def nick_double_clicked(self, item):
         chatter = self.nickList.item(item.row(), Chatter.SORT_COLUMN)  # Look up the associated chatter object
-        chatter.doubleClicked(item)
+        chatter.double_clicked(item)
 
     @QtCore.pyqtSlot(QtWidgets.QTableWidgetItem)
-    def nickPressed(self, item):
+    def nick_pressed(self, item):
         if QtWidgets.QApplication.mouseButtons() == QtCore.Qt.RightButton:
             # Look up the associated chatter object
             chatter = self.nickList.item(item.row(), Chatter.SORT_COLUMN)
             chatter.pressed(item)
 
-    def updateChatters(self):
+    def update_chatters(self):
         """
         Triggers all chatters to update their status. Called when toggling map icon display in settings
         """
         for _, chatter in self.chatters.items():
             chatter.update()
 
-        self.resizeMapColumn()
+        self.resize_map_column()
 
-    def resizeMapColumn(self):
+    def resize_map_column(self):
         if util.settings.value("chat/chatmaps", False):
             self.nickList.horizontalHeader().resizeSection(Chatter.MAP_COLUMN, Formatters.NICKLIST_COLUMNS['MAP'])
         else:
             self.nickList.horizontalHeader().resizeSection(Chatter.MAP_COLUMN, 0)
 
-    def addChatter(self, chatter, join=False):
+    def add_chatter(self, chatter, join=False):
         """
         Adds an user to this chat channel, and assigns an appropriate icon depending on friendship and FAF player status
         """
@@ -422,38 +422,38 @@ class Channel(FormClass, BaseClass):
 
         self.chatters[chatter].update()
 
-        self.updateUserCount()
+        self.update_user_count()
 
         if join and self.chat_widget.client.joinsparts:
-            self.printAction(chatter.name, "joined the channel.", server_action=True)
+            self.print_action(chatter.name, "joined the channel.", server_action=True)
 
-    def removeChatter(self, chatter, server_action=None):
+    def remove_chatter(self, chatter, server_action=None):
         if chatter in self.chatters:
             self.nickList.removeRow(self.chatters[chatter].row())
             del self.chatters[chatter]
 
             if server_action and (self.chat_widget.client.joinsparts or self.private):
-                self.printAction(chatter.name, server_action, server_action=True)
-                self.stopBlink()
+                self.print_action(chatter.name, server_action, server_action=True)
+                self.stop_blink()
 
-        self.updateUserCount()
+        self.update_user_count()
 
-    def verifySortOrder(self, chatter):
+    def verify_sort_order(self, chatter):
         row = chatter.row()
         next_chatter = self.nickList.item(row + 1, Chatter.SORT_COLUMN)
         prev_chatter = self.nickList.item(row - 1, Chatter.SORT_COLUMN)
 
         if (next_chatter is not None and chatter > next_chatter or
            prev_chatter is not None and chatter < prev_chatter):
-            self.sortCall.scheduleCall()
+            self.sort_call.schedule_call()
 
-    def setAnnounceText(self, text):
+    def set_announce_text(self, text):
         self.announceLine.clear()
         self.announceLine.setText("<style>a{color:cornflowerblue}</style><b><font color=white>" + util.irc_escape(text) + "</font></b>")
 
     @QtCore.pyqtSlot()
-    def sendLine(self, target=None):
-        self.stopBlink()
+    def send_line(self, target=None):
+        self.stop_blink()
 
         if not target:
             target = self.name  # pubmsg in channel
@@ -475,24 +475,24 @@ class Channel(FormClass, BaseClass):
                 if text.startswith("/join "):
                     self.chat_widget.join(text[6:])
                 elif text.startswith("/topic "):
-                    self.chat_widget.setTopic(self.name, text[7:])
+                    self.chat_widget.set_topic(self.name, text[7:])
                 elif text.startswith("/msg "):
                     blobs = text.split(" ")
-                    self.chat_widget.sendMsg(blobs[1], " ".join(blobs[2:]))
+                    self.chat_widget.send_msg(blobs[1], " ".join(blobs[2:]))
                 elif text.startswith("/me "):
-                    if self.chat_widget.sendAction(target, text[4:]):
-                        self.printAction(self.chat_widget.client.login, text[4:], True)
+                    if self.chat_widget.send_action(target, text[4:]):
+                        self.print_action(self.chat_widget.client.login, text[4:], True)
                     else:
-                        self.printAction("IRC", "action not supported", True)
+                        self.print_action("IRC", "action not supported", True)
                 elif text.startswith("/seen "):
-                    if self.chat_widget.sendMsg("nickserv", "info %s" % (text[6:])):
-                        self.printAction("IRC", "info requested on %s" % (text[6:]), True)
+                    if self.chat_widget.send_msg("nickserv", "info %s" % (text[6:])):
+                        self.print_action("IRC", "info requested on %s" % (text[6:]), True)
                     else:
-                        self.printAction("IRC", "not connected", True)
+                        self.print_action("IRC", "not connected", True)
             else:
-                if self.chat_widget.sendMsg(target, text):
-                    self.printMsg(self.chat_widget.client.login, text, True)
+                if self.chat_widget.send_msg(target, text):
+                    self.print_msg(self.chat_widget.client.login, text, True)
         self.chatEdit.clear()
 
-    def _checkUserQuit(self, chatter):
-        self.removeChatter(chatter, 'quit.')
+    def _check_user_quit(self, chatter):
+        self.remove_chatter(chatter, 'quit.')

--- a/src/chat/chatlineedit.py
+++ b/src/chat/chatlineedit.py
@@ -15,7 +15,7 @@ class ChatLineEdit(QtWidgets.QLineEdit):
     """
     def __init__(self, parent):
         QtWidgets.QLineEdit.__init__(self, parent)
-        self.returnPressed.connect(self.onLineEntered)
+        self.returnPressed.connect(self.on_line_entered)
         self.history = []
         self.currentHistoryIndex = None
         self.historyShown = False
@@ -24,35 +24,35 @@ class ChatLineEdit(QtWidgets.QLineEdit):
         self.LocalChatterNameList = []
         self.currenLocalChatter = None
 
-    def setChatters(self, chatters):
+    def set_chatters(self, chatters):
         self.chatters = chatters
 
     def event(self, event):
         if event.type() == QtCore.QEvent.KeyPress:
             # Swallow a selection of keypresses that we want for our history support.
             if event.key() == QtCore.Qt.Key_Tab:
-                self.tryCompletion()
+                self.try_completion()
                 return True
             elif event.key() == QtCore.Qt.Key_Space:
-                self.acceptCompletion()
+                self.accept_completion()
                 return QtWidgets.QLineEdit.event(self, event)
             elif event.key() == QtCore.Qt.Key_Up:
-                self.cancelCompletion()
-                self.prevHistory()
+                self.cancel_completion()
+                self.prev_history()
                 return True
             elif event.key() == QtCore.Qt.Key_Down:
-                self.cancelCompletion()
-                self.nextHistory()
+                self.cancel_completion()
+                self.next_history()
                 return True
             else:
-                self.cancelCompletion()
+                self.cancel_completion()
                 return QtWidgets.QLineEdit.event(self, event)
 
         # All other events (non-keypress)
         return QtWidgets.QLineEdit.event(self, event)
 
     @QtCore.pyqtSlot()
-    def onLineEntered(self):
+    def on_line_entered(self):
         self.history.append(self.text())
         self.currentHistoryIndex = len(self.history) - 1
 
@@ -60,7 +60,7 @@ class ChatLineEdit(QtWidgets.QLineEdit):
         self.setFocus(True)
         return QtWidgets.QLineEdit.showEvent(self, event)
 
-    def tryCompletion(self):
+    def try_completion(self):
         if not self.completionStarted:
             # no completion on empty line
             if self.text() == "":
@@ -90,20 +90,20 @@ class ChatLineEdit(QtWidgets.QLineEdit):
                 self.currenLocalChatter = (self.currenLocalChatter + 1) % len(self.LocalChatterNameList)
                 self.setText(self.completionLine + self.LocalChatterNameList[self.currenLocalChatter])
 
-    def acceptCompletion(self):
+    def accept_completion(self):
         self.completionStarted = False
 
-    def cancelCompletion(self):
+    def cancel_completion(self):
         self.completionStarted = False
 
-    def prevHistory(self):
+    def prev_history(self):
         if self.currentHistoryIndex is not None:  # no history nothing to do
             if self.currentHistoryIndex > 0 and self.historyShown:  # check for boundaries and only change index is hostory is alrady shown
                 self.currentHistoryIndex -= 1
             self.historyShown = True
             self.setText(self.history[self.currentHistoryIndex])
     
-    def nextHistory(self):
+    def next_history(self):
         if self.currentHistoryIndex is not None:
             if self.currentHistoryIndex < len(self.history)-1 and self.historyShown:  # check for boundaries and only change index is hostory is alrady shown
                 self.currentHistoryIndex += 1

--- a/src/chat/chatter.py
+++ b/src/chat/chatter.py
@@ -46,8 +46,8 @@ class Chatter(QtWidgets.QTableWidgetItem):
         self.channel = channel
 
         self._me = me
-        self._me.relationsUpdated.connect(self._checkPlayerRelation)
-        self._me.ircRelationsUpdated.connect(self._checkUserRelation)
+        self._me.relationsUpdated.connect(self._check_player_relation)
+        self._me.ircRelationsUpdated.connect(self._check_user_relation)
 
         self._map_dl_request = PreviewDownloadRequest()
         self._map_dl_request.done.connect(self._on_map_downloaded)
@@ -99,14 +99,14 @@ class Chatter(QtWidgets.QTableWidgetItem):
     def user(self, value):
         if self._user is not None:
             self.user_player = None  # Clears game as well
-            self._user.updated.disconnect(self.updateUser)
+            self._user.updated.disconnect(self.update_user)
             self._user.newPlayer.disconnect(self._set_user_player)
 
         self._user = value
-        self.updateUser()
+        self.update_user()
 
         if self._user is not None:
-            self._user.updated.connect(self.updateUser)
+            self._user.updated.connect(self.update_user)
             self._user.newPlayer.connect(self._set_user_player)
             self.user_player = self._user.player
 
@@ -121,14 +121,14 @@ class Chatter(QtWidgets.QTableWidgetItem):
     def user_player(self, value):
         if self._user_player is not None:
             self.user_game = None
-            self._user_player.updated.disconnect(self.updatePlayer)
+            self._user_player.updated.disconnect(self.update_player)
             self._user_player.newCurrentGame.disconnect(self._set_user_game)
 
         self._user_player = value
-        self.updatePlayer()
+        self.update_player()
 
         if self._user_player is not None:
-            self._user_player.updated.connect(self.updatePlayer)
+            self._user_player.updated.connect(self.update_player)
             self._user_player.newCurrentGame.connect(self._set_user_game)
             self.user_game = self._user_player.currentGame
 
@@ -142,30 +142,30 @@ class Chatter(QtWidgets.QTableWidgetItem):
     @user_game.setter
     def user_game(self, value):
         if self._user_game is not None:
-            self._user_game.gameUpdated.disconnect(self.updateGame)
-            self._user_game.liveReplayAvailable.disconnect(self.updateGame)
+            self._user_game.gameUpdated.disconnect(self.update_game)
+            self._user_game.liveReplayAvailable.disconnect(self.update_game)
 
         self._user_game = value
-        self.updateGame()
+        self.update_game()
 
         if self._user_game is not None:
-            self._user_game.gameUpdated.connect(self.updateGame)
-            self._user_game.liveReplayAvailable.connect(self.updateGame)
+            self._user_game.gameUpdated.connect(self.update_game)
+            self._user_game.liveReplayAvailable.connect(self.update_game)
 
-    def _checkPlayerRelation(self, players):
+    def _check_player_relation(self, players):
         if self.user_player is None:
             return
 
         if self.user_player.id in players:
             self.set_color()
-            self._verifySortOrder()
+            self._verify_sort_order()
 
-    def _checkUserRelation(self, users):
+    def _check_user_relation(self, users):
         if self.user.name in users:
             self.set_color()
-            self._verifySortOrder()
+            self._verify_sort_order()
 
-    def isFiltered(self, _filter):
+    def is_filtered(self, _filter):
         clan = None if self.user_player is None else self.user_player.clan
         clan = clan if clan is not None else ""
         name = self.user.name
@@ -173,7 +173,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
             return True
         return False
 
-    def setVisible(self, visible):
+    def set_visible(self, visible):
         if visible:
             self.tableWidget().showRow(self.row())
         else:
@@ -201,11 +201,11 @@ class Chatter(QtWidgets.QTableWidgetItem):
         # Default: Alphabetical
         return self.user.name.lower() < other.user.name.lower()
 
-    def _verifySortOrder(self):
+    def _verify_sort_order(self):
         if self.row() != -1:
-            self.channel.verifySortOrder(self)
+            self.channel.verify_sort_order(self)
 
-    def _getIdName(self):
+    def _get_id_name(self):
         _id = -1 if self.user_player is None else self.user_player.id
         name = self.user.name
         return _id, name
@@ -213,8 +213,8 @@ class Chatter(QtWidgets.QTableWidgetItem):
     def get_user_rank(self, user):
         # TODO: Add subdivision for admin?
         me = self._me
-        _id, name = user._getIdName()
-        if user.modElevation():
+        _id, name = user._get_id_name()
+        if user.mod_elevation():
             return self.RANK_ELEVATION
         if me.isFriend(_id, name):
             return self.RANK_FRIEND - (2 if self.chat_widget.client.friendsontop else 0)
@@ -225,12 +225,12 @@ class Chatter(QtWidgets.QTableWidgetItem):
 
         return self.RANK_NONPLAYER
 
-    def modElevation(self):
+    def mod_elevation(self):
         if not self.user.is_mod(self.channel.name):
             return None
         return self.user.elevation[self.channel.name]
 
-    def updateAvatar(self):
+    def update_avatar(self):
         # FIXME: prodding the underlying C++ object to see if it exists
         # Needed if we're gone while downloading our avatar
         # We don't subclass QObject, so we have to do it this way
@@ -238,7 +238,6 @@ class Chatter(QtWidgets.QTableWidgetItem):
             self.isSelected()
         except RuntimeError:
             return
-
         try:
             avatar = self.user_player.avatar
         except AttributeError:
@@ -267,16 +266,16 @@ class Chatter(QtWidgets.QTableWidgetItem):
         else:
             self.setText(self.user.name)
 
-    def updateUser(self):
+    def update_user(self):
         self.set_chatter_name()
         self.set_color()
-        self._verifySortOrder()
+        self._verify_sort_order()
 
-    def updatePlayer(self):
+    def update_player(self):
         self.set_chatter_name()
         self.update_rank()
         self.update_country()
-        self.updateAvatar()
+        self.update_avatar()
 
     def update_country(self):
         player = self.user_player
@@ -318,7 +317,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
         self.rankItem.setIcon(util.THEME.icon("chat/rank/{}.png".format(icon_str)))
         self.rankItem.setToolTip(tooltip_str)
 
-    def updateGame(self):
+    def update_game(self):
         self.update_status_tooltip()
         self.update_status_icon()
         self.update_map()
@@ -406,52 +405,52 @@ class Chatter(QtWidgets.QTableWidgetItem):
         self.mapItem.setIcon(util.THEME.icon(path, is_local))
 
     def update(self):
-        self.updateUser()
-        self.updatePlayer()
-        self.updateGame()
+        self.update_user()
+        self.update_player()
+        self.update_game()
 
     def set_color(self):
         # FIXME - we should really get colors in the constructor
         pcolors = self.chat_widget.client.player_colors
-        elevation = self.modElevation()
-        _id, name = self._getIdName()
+        elevation = self.mod_elevation()
+        _id, name = self._get_id_name()
         if elevation is not None:
             color = pcolors.getModColor(elevation, _id, name)
         else:
             color = pcolors.getUserColor(_id, name)
         self.setForeground(QtGui.QColor(color))
 
-    def viewAliases(self):
+    def view_aliases(self):
         if self.user_player is not None:
             player_id = self.user_player.id
         else:
             player_id = None
         self._aliases.view_aliases(self.user.name, player_id)
 
-    def selectAvatar(self):
+    def select_avatar(self):
         avatarSelection = AvatarWidget(self.chat_widget.client, self.user.name, personal=True)
         avatarSelection.exec_()
 
-    def addAvatar(self):
+    def add_avatar(self):
         avatarSelection = AvatarWidget(self.chat_widget.client, self.user.name)
         avatarSelection.exec_()
 
     def kick(self):
         pass
 
-    def doubleClicked(self, item):
+    def double_clicked(self, item):
         # filter yourself
         if self._me.login is not None:
             if self._me.login == self.user.name:
                 return
         # Chatter name clicked
         if item == self:
-            self.chat_widget.openQuery(self.user, activate=True)  # open and activate query window
+            self.chat_widget.open_query(self.user, activate=True)  # open and activate query window
 
         elif item == self.statusItem:
-            self._interactWithGame()
+            self._interact_with_game()
 
-    def _interactWithGame(self):
+    def _interact_with_game(self):
         game = self.user_game
         if game is None or game.closed():
             return
@@ -474,7 +473,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
 
         player = self.user_player
         game = self.user_game
-        _id, name = self._getIdName()
+        _id, name = self._get_id_name()
 
         if player is None or self._me.player is None:
             is_me = False
@@ -482,12 +481,12 @@ class Chatter(QtWidgets.QTableWidgetItem):
             is_me = player.id == self._me.player.id
 
         if is_me:  # only for us. Either way, it will display our avatar, not anyone avatar.
-            menu_add("Select Avatar", self.selectAvatar)
+            menu_add("Select Avatar", self.select_avatar)
 
         # power menu
         if self.chat_widget.client.power > 1:
             # admin and mod menus
-            menu_add("Assign avatar", self.addAvatar, True)
+            menu_add("Assign avatar", self.add_avatar, True)
 
             if self.chat_widget.client.power == 2:
 
@@ -502,7 +501,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
                 menu_add("Close Game", lambda: self.chat_widget.client.closeFA(name))
                 menu_add("Close FAF Client", lambda: self.chat_widget.client.closeLobby(name))
 
-        menu_add("View Aliases", self.viewAliases, True)
+        menu_add("View Aliases", self.view_aliases, True)
         if player is not None:  # not for irc user
             if int(player.ladder_estimate()) != 0:  # not for 'never played ladder'
                 menu_add("View in Leaderboards", self.view_in_leaderboards)
@@ -510,7 +509,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
         # Don't allow self to be invited to a game, or join one
         if game is not None and not is_me:
             if game.state == GameState.OPEN:
-                menu_add("Join hosted Game", self._interactWithGame, True)
+                menu_add("Join hosted Game", self._interact_with_game, True)
             elif game.state == GameState.PLAYING:
                 time_running = time.time() - game.launched_at
                 if game.has_live_replay:
@@ -520,14 +519,14 @@ class Chatter(QtWidgets.QTableWidgetItem):
                 else:
                     wait_str = time.strftime('%M:%S', time.gmtime(game.LIVE_REPLAY_DELAY_SECS - time_running))
                     action_str = "WAIT " + wait_str + " to view Live Replay"
-                menu_add(action_str, self._interactWithGame, True)
+                menu_add(action_str, self._interact_with_game, True)
 
         if player is not None:  # not for irc user
             menu_add("View Replays in Vault", self.view_vault_replay, True)
 
         # Friends and Foes Lists
         def player_or_irc_action(f, irc_f):
-            _id, name = self._getIdName()
+            _id, name = self._get_id_name()
             if player is not None:
                 return lambda: f(_id)
             else:
@@ -544,7 +543,7 @@ class Chatter(QtWidgets.QTableWidgetItem):
         else:  # We're neither
             menu_add("Add friend", player_or_irc_action(cl.addFriend, me.addIrcFriend), True)
             # FIXME - chatwidget sets mod status very inconsistently
-            if self.modElevation() is None:  # so disable foeing mods for now
+            if self.mod_elevation() is None:  # so disable foeing mods for now
                 menu_add("Add foe", player_or_irc_action(cl.addFoe, me.addIrcFoe))
 
         # Finally: Show the popup

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -29,8 +29,7 @@ from model.player import Player
 from model.playerset import Playerset
 from modvault.utils import MODFOLDER
 import notifications as ns
-import replays
-import secondaryServer
+from secondaryServer import SecondaryServer
 import time
 import util
 from ui.status_logo import StatusLogo
@@ -195,7 +194,7 @@ class ClientWindow(FormClass, BaseClass):
         self.connectivity = None  # type: ConnectivityHelper
 
         # stat server
-        self.statsServer = secondaryServer.SecondaryServer("Statistic", 11002, self.lobby_dispatch)
+        self.statsServer = SecondaryServer("Statistic", 11002, self.lobby_dispatch)
 
         # create user interface (main window) and load theme
         self.setupUi(self)
@@ -422,7 +421,7 @@ class ClientWindow(FormClass, BaseClass):
 
     def mousePressEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
-            if self.mousePosition.isOnEdge() and self.maxNormal == False:
+            if self.mousePosition.isOnEdge() and not self.maxNormal:
                 self.dragging = True
                 return
             else:
@@ -452,7 +451,7 @@ class ClientWindow(FormClass, BaseClass):
 
             else:
                 self.rubberBand.hide()
-                if self.maxNormal == True:
+                if self.maxNormal:
                     self.showMaxRestore()
 
             self.move(event.globalPos() - self.offset)
@@ -507,16 +506,16 @@ class ClientWindow(FormClass, BaseClass):
             self.setGeometry(newRect)
 
     def setup(self):
-        import news
-        import chat
-        import coop
-        import games
-        import tutorials
-        import stats
-        import tourneys
-        import vault
-        import modvault
-        import downloadManager
+        from news import NewsWidget
+        from chat import ChatWidget
+        from coop import CoopWidget
+        from games import GamesWidget
+        from tutorials import TutorialsWidget
+        from stats import StatsWidget
+        from tourneys import TournamentsWidget
+        from vault import MapVault
+        from modvault import ModVault
+        from replays import ReplaysWidget
         from chat._avatarWidget import AvatarWidget
 
         self.loadSettings()
@@ -528,19 +527,19 @@ class ClientWindow(FormClass, BaseClass):
                                             self.map_downloader)
 
         # build main window with the now active client
-        self.news = news.NewsWidget(self)
-        self.chat = chat.ChatWidget(self, self.players, self.me)
-        self.coop = coop.CoopWidget(self, self.game_model, self.me,
-                                    self.gameview_builder, self.game_launcher)
-        self.games = games.GamesWidget(self, self.game_model, self.me,
-                                       self.gameview_builder, self.game_launcher)
-        self.tutorials = tutorials.TutorialsWidget(self)
-        self.ladder = stats.StatsWidget(self)
-        self.tourneys = tourneys.TournamentsWidget(self)
-        self.replays = replays.ReplaysWidget(self, self.lobby_dispatch,
-                                             self.gameset, self.players)
-        self.mapvault = vault.MapVault(self)
-        self.modvault = modvault.ModVault(self)
+        self.news = NewsWidget(self)
+        self.chat = ChatWidget(self, self.players, self.me)
+        self.coop = CoopWidget(self, self.game_model, self.me,
+                               self.gameview_builder, self.game_launcher)
+        self.games = GamesWidget(self, self.game_model, self.me,
+                                 self.gameview_builder, self.game_launcher)
+        self.tutorials = TutorialsWidget(self)
+        self.ladder = StatsWidget(self)
+        self.tourneys = TournamentsWidget(self)
+        self.replays = ReplaysWidget(self, self.lobby_dispatch,
+                                     self.gameset, self.players)
+        self.mapvault = MapVault(self)
+        self.modvault = ModVault(self)
         self.notificationSystem = ns.Notifications(self, self.gameset,
                                                    self.players, self.me)
 
@@ -780,13 +779,13 @@ class ClientWindow(FormClass, BaseClass):
         self.player_colors.coloredNicknames = self.actionColoredNicknames.isChecked()
         if self.friendsontop != self.actionFriendsOnTop.isChecked():
             self.friendsontop = self.actionFriendsOnTop.isChecked()
-            self.chat.sortChannels()
+            self.chat.sort_channels()
 
         self.saveChat()
 
     def toggleChatMaps(self):
         self.updateOptions()
-        self.chat.updateChannels()
+        self.chat.update_channels()
 
     @QtCore.pyqtSlot()
     def switchPath(self):

--- a/src/replays/replayitem.py
+++ b/src/replays/replayitem.py
@@ -118,7 +118,7 @@ class ReplayItem(QtWidgets.QTreeWidgetItem):
 
         self._map_dl_request = PreviewDownloadRequest()
         self._map_dl_request.done.connect(self._on_map_preview_downloaded)
-    
+
     def update(self, message, client):
         """ Updates this item from the message dictionary supplied """
         


### PR DESCRIPTION
This is a suggestion to keep to the python convention (exampled on the chat dir).

Because, I see different functions - Qt, python - with the same name, that is confusing.

example: autoJoin in _clientwindow is a QtSignal, while in _chatwidget it's a python function.

I made the python functions lower case, and kept the mixed case to Qt stuff.