### PR TITLE
add ladder map delayed reveal in chat - fix #360

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,9 +15,11 @@
  * Hotfix race condition between downloading avatars and removing chatters (#957)
  * Don't proceed with game launch if FA path is invalid (#933, #959)
  * Hotfix an irclib exception popping up in some cases (#958)
+ * Delay displaying of user's ladder game info until launch (#360, #912)
 
 Contributors:
  - Wesmania
+ - Grothe
 
 0.16.1-rc.2
 ====

--- a/src/chat/gameinfo.py
+++ b/src/chat/gameinfo.py
@@ -1,0 +1,23 @@
+from PyQt5.QtCore import QObject
+from model.game import GameState
+
+
+class SensitiveMapInfoChecker(QObject):
+    def __init__(self, me):
+        QObject.__init__(self)
+        self._me = me
+
+    def has_sensitive_data(self, game):
+        if game is None or game.closed():
+            return False
+
+        if game.featured_mod == "ladder1v1":
+            return self._ladder_has_sensitive_data(game)
+        return False
+
+    def _ladder_has_sensitive_data(self, game):
+        if game.state != GameState.OPEN:
+            return False
+        if self._me.player is None:
+            return False
+        return self._me.player.login in game.players


### PR DESCRIPTION
this should fix #360 which might be worsened by now the map shown in chat

add ladder_hide during game state=open to hide game.map and game.title (reveals oponent) to the client user.
untestet - if that's enough .. it should be ... but better be sure.
