### PR TITLE
Initialize game sorting order explicitly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 0.x.x
 =====
 
+0.16.1-rc.3
+====
+ * Fix game sorting sometimes not matching saved settings at startup (#918, #919)
+
+Contributors:
+ - Wesmania
+
 0.16.1-rc.2
 ====
  * Introduce new object model:

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -80,7 +80,10 @@ class GamesWidget(FormClass, BaseClass):
             safe_sort_index = self.sort_games_index
         except ValueError:
             safe_sort_index = 0
+        # This only triggers the signal if the index actually changes,
+        # so let's initialize it ourselves
         self.sortGamesComboBox.setCurrentIndex(safe_sort_index)
+        self.sortGamesComboChanged(safe_sort_index)
 
         self.hideGamesWithPw.stateChanged.connect(self.togglePrivateGames)
         self.hideGamesWithPw.setChecked(self.hide_private_games)


### PR DESCRIPTION
If the sort index was exactly the same as initial combobox index, the
combobox wouldn't emit index change signal and the model would keep its
default (different) sorting order. Explictly call the model index change
method in __init__.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
