### PR TITLE
Remove explicit list type from autojoin setting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ====
  * Fix game sorting sometimes not matching saved settings at startup (#918, #919)
  * Fix players in chat sometimes not displayed with their clan tags (#922, #923)
+ * Fix channel autojoin settings not loading properly
 
 Contributors:
  - Wesmania

--- a/src/chat/_chatwidget.py
+++ b/src/chat/_chatwidget.py
@@ -32,7 +32,7 @@ class ChatWidget(FormClass, BaseClass, SimpleIRCClient):
     irc_host = Settings.persisted_property('chat/host', type=str, default_value='irc.' + defaults['host'])
     irc_tls = Settings.persisted_property('chat/tls', type=bool, default_value=False)
 
-    auto_join_channels = Settings.persisted_property('chat/auto_join_channels', type=list, default_value=[])
+    auto_join_channels = Settings.persisted_property('chat/auto_join_channels', default_value=[])
 
     """
     This is the chat lobby module for the FAF client.


### PR DESCRIPTION
Using an explicit list type for the setting causes weird exceptions when loading it that go away if you omit it. This commit will require some more testing (empty setting values, removed setting, setting with one and multiple channels) to make sure it doesn't crash and we don't need to fix it up again. Volunteers welcome!

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>