### PR TITLE
Refactor chatter updates to fix inconsistent updates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 0.16.1-rc.3
 ====
  * Fix game sorting sometimes not matching saved settings at startup (#918, #919)
+ * Fix players in chat sometimes not displayed with their clan tags (#922, #923)
 
 Contributors:
  - Wesmania


### PR DESCRIPTION
Chatter name wasn't updating consistently between chatter and player
updates. Now all update details are put in separate argumentless
methods, so there should be no more inconsistencies when updating.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [x] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
