### PR TITLE
readded xdelta3 extension [FIX]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 0.x.x
 =====
 
-0.17.0
+0.16.0-rc.2
 ====
  * Introduce new object model:
    - Game, Player and IrcUser classes track corresponding info from the server,

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -706,6 +706,9 @@ class Updater(QtCore.QObject, ConnectionHandler):
             xdelta = os.path.join(fafpath.get_libdir(), "xdelta3.exe")
         else:
             xdelta = "xdelta3"
+            if not shutil.which(xdelta):
+                QtWidgets.QMessageBox.information(None, "xdelta3 not found", 
+                                    "Please install xdelta3 on your system.")
         subprocess.call([xdelta, '-d', '-f', '-s', original, patch, toFile], stdout=subprocess.PIPE)
         shutil.copy(toFile, original)
         os.remove(toFile)

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -707,8 +707,7 @@ class Updater(QtCore.QObject, ConnectionHandler):
         else:
             xdelta = "xdelta3"
             if not shutil.which(xdelta):
-                QtWidgets.QMessageBox.information(None, "xdelta3 not found", 
-                                    "Please install xdelta3 on your system.")
+                logger.error("%s not found on the system" % xdelta)
         subprocess.call([xdelta, '-d', '-f', '-s', original, patch, toFile], stdout=subprocess.PIPE)
         shutil.copy(toFile, original)
         os.remove(toFile)


### PR DESCRIPTION
This was necessary to fix the client on my GNU/Linux system. 
Otherwise it gives me an error message that it can't find xdelta3.exe

Was the extension deliberately missing on platforms that don't identify as **win32**?