### PR TITLE
Don't show checked name in list of other alias users

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
  * Fix game sorting sometimes not matching saved settings at startup (#918, #919)
  * Fix players in chat sometimes not displayed with their clan tags (#922, #923)
  * Fix channel autojoin settings not loading properly
+ * Don't show checked user's name among other alias users
 
 Contributors:
  - Wesmania

--- a/src/client/aliasviewer.py
+++ b/src/client/aliasviewer.py
@@ -194,7 +194,7 @@ class AliasWindow:
             return
 
         alias_format = self._fmt.names_previously_known(player_aliases)
-        others_format = self._fmt.name_used_by_others(other_users)
+        others_format = self._fmt.name_used_by_others(other_users, name)
         result = '{}<br/><br/>{}'.format(alias_format, others_format)
         QtWidgets.QMessageBox.about(self._parent,
                                     "Aliases : {}".format(name),


### PR DESCRIPTION
Now the aliases box doesn't show the user we check among other alias users.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
