### PR TITLE
Restore quit messages when a chatter quits

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
  * Don't show checked user's name among other alias users
  * Fix host and link in announcements in chat (#930, #934)
  * Fix '/me' message formatting for senders with no avatars (#936, #940)
+ * Restore the 'quit' server message when a chatter quits chat (#937, #939)
 
 Contributors:
  - Wesmania

--- a/src/chat/channel.py
+++ b/src/chat/channel.py
@@ -491,4 +491,4 @@ class Channel(FormClass, BaseClass):
         self.chatEdit.clear()
 
     def _checkUserQuit(self, chatter):
-        self.removeChatter(chatter)
+        self.removeChatter(chatter, 'quit.')


### PR DESCRIPTION
We use a 'chatter removed' signal for that which doesn't differentiate
between a user genuinely disconnecting and just being removed from the
set (if we disconnect and restore our state for example), but it will do
for now.

Fixes #937.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
