### PR TITLE
Revert to a proper formatter if sender has no avatar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
  * Fix channel autojoin settings not loading properly
  * Don't show checked user's name among other alias users
  * Fix host and link in announcements in chat (#930, #934)
+ * Fix '/me' message formatting for senders with no avatars (#936, #940)
 
 Contributors:
  - Wesmania


### PR DESCRIPTION
If the sender had no avatar, formatting always reverted to regular
message, which broke '/me' formatting. Convert formatters properly if
there's no avatar.

Fixes #936.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
