### PR TITLE
fix #943 chat user context menu View Replays in Vault

### DIFF
--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -456,13 +456,13 @@ class ReplayVaultWidgetHandler(object):
 
     def searchVault(self, minRating=None, mapName=None, playerName=None, modListIndex=None):
         w = self._w
-        if minRating:
+        if minRating is not None:
             w.minRating.setValue(minRating)
-        if mapName:
+        if mapName is not None:
             w.mapName.setText(mapName)
-        if playerName:
+        if playerName is not None:
             w.playerName.setText(playerName)
-        if modListIndex:
+        if modListIndex is not None:
             w.modList.setCurrentIndex(modListIndex)
 
         """ search for some replays """


### PR DESCRIPTION
3 out of 5 given values weren't set. so if there was a prior search it wasn't proper cleared.
