### PR TITLE
fix #944 click user game announcement link if game has ended

### DIFF
--- a/src/fa/replay.py
+++ b/src/fa/replay.py
@@ -87,7 +87,7 @@ def replay(source, detach=False):
             if url.scheme() == "faflive":
                 mod = QtCore.QUrlQuery(url).queryItemValue("mod")
                 mapname = QtCore.QUrlQuery(url).queryItemValue("map")
-                replay_id = url.path().split("/")[0]
+                replay_id = QtCore.QUrlQuery(url).queryItemValue("uid")
                 # whip the URL into shape so ForgedAllianceForever.exe understands it
                 arg_url = QtCore.QUrl(url)
                 arg_url.setScheme("gpgnet")

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -231,11 +231,12 @@ class Game(QObject):
         query = QUrlQuery()
         query.addQueryItem("map", self.mapname)
         query.addQueryItem("mod", self.featured_mod)
+        query.addQueryItem("uid", str(self.uid))
+        query.addQueryItem("player", str(self._playerset[player_id].login))
 
         if self.state == GameState.OPEN:
             url.setScheme("fafgame")
             url.setPath("/" + str(player_id))
-            query.addQueryItem("uid", str(self.uid))
         else:
             url.setScheme("faflive")
             url.setPath("/" + str(self.uid) + "/" + str(player_id) + ".SCFAreplay")


### PR DESCRIPTION
In Chat a click on player live game announcement when game had ended, let to fa starting with error message.
Now it will give a message about game ended, with an option to search the users replays in Vault.
And click on host game announcements will now be checked for game started (message with option to watch the live game) and game ended (message).