### PR TITLE
fix #599 Replay Search map - blank handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 
 0.17.0
 =====
- * Fixed the error message "failed to get uid" which has bad spacing
+ * Fix the error message "failed to get uid" which has bad spacing
+ * Fix replay search map - automatic replacement of blanks with * (#955, #599)
 
 Contributors:
  - MathieuB8

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -465,13 +465,16 @@ class ReplayVaultWidgetHandler(object):
         if modListIndex is not None:
             w.modList.setCurrentIndex(modListIndex)
 
+        # Map Search helper - the secondary server has a problem with blanks (fix until change to api)
+        map_name = w.mapName.text().replace(" ", "*")
+
         """ search for some replays """
         self._w.searchInfoLabel.setText(self.searchInfo)
         self.searching = True
         self.vault_connection.connect()
         self.vault_connection.send(dict(command="search",
                                         rating=w.minRating.value(),
-                                        map=w.mapName.text(),
+                                        map=map_name,
                                         player=w.playerName.text(),
                                         mod=w.modList.currentText()))
         self._w.onlineTree.clear()


### PR DESCRIPTION
Map name with blanks leads to useless or no result.
Replacing blanks with * and all works out fine.
Yes, that easy ...  fix #599

One downside: search for 'Super Map' will also give 'Super Duper Map'.