### PR TITLE
refactor mod vault

### DIFF
--- a/res/modvault/modinfo.qthtml
+++ b/res/modvault/modinfo.qthtml
@@ -1,16 +1,13 @@
-<font color="{color}" size="+2"><b>{title} V{version}</b></font>
-<font color="silver" size="-1">
-{modtype}
-<p width="230">
-{description}
-</p>
+<font color="silver">
+<font color="{color}" size="+2"><b>{title}</b><font size="+1"> (version: {version})</font></font> {modtype}<br/>
+<b>{description}</b>
 <table border=0 cellpadding="0" cellspacing="0" width="230">
 <tbody>
-<tr><td><i>Author:</i> {author}</td></tr>
-<tr><td><i>Downloads:</i> {downloads}</td></tr>
-<tr><td><i>Played:</i> {played} times</td></tr>
-<tr><td><i>{likes} Liked this</td></tr>
-<tr><td><i>Uploaded {date}</i></td></tr>
+<tr><td>Author: {author}</td></tr>
+<tr><td>Downloads: {downloads}</td></tr>
+<tr><td>Played: {played} times</td></tr>
+<tr><td>{likes} liked this</td></tr>
+<tr><td>Uploaded {date}</td></tr>
 </tbody>
 </table>
 </font>

--- a/res/modvault/modinfoui.qthtml
+++ b/res/modvault/modinfoui.qthtml
@@ -1,15 +1,12 @@
-<font color="{color}" size="+2"><b>{title} V{version}</b></font>
-<font color="silver" size="-1">
-{modtype}
-<p width="230">
-{description}
-</p>
+<font color="silver">
+<font color="{color}" size="+2"><b>{title}</b><font size="+1"> (version: {version})</font></font> {modtype}<br/>
+<b>{description}</b>
 <table border=0 cellpadding="0" cellspacing="0" width="230">
 <tbody>
-<tr><td><i>Author:</i> {author}</td></tr>
-<tr><td><i>Downloads:</i> {downloads}</td></tr>
-<tr><td><i>{likes} Liked this</td></tr>
-<tr><td><i>Uploaded {date}</i></td></tr>
+<tr><td>Author: {author}</td></tr>
+<tr><td>Downloads: {downloads}</td></tr>
+<tr><td>{likes} Liked this</td></tr>
+<tr><td>Uploaded {date}</td></tr>
 </tbody>
 </table>
 </font>

--- a/res/modvault/modvault.ui
+++ b/res/modvault/modvault.ui
@@ -29,6 +29,16 @@
       <number>5</number>
      </property>
      <item>
+      <widget class="QLabel" name="labelmodVaultInfo">
+       <property name="text">
+        <string>Pressing Enter in the search box will only filter the list of mods. A click on 'Server Search' will make a new server request with the search box as filter. The server response is limited to 100, but the client adds newly received mods to his distinct list, so the list will grow beyond 100. The search is case insensitive and is taken as one string (even incl. blanks), and no wildcards (? *).</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout_6">
        <property name="spacing">
         <number>5</number>
@@ -49,7 +59,7 @@
         <widget class="QLineEdit" name="searchInput">
          <property name="minimumSize">
           <size>
-           <width>110</width>
+           <width>100</width>
            <height>0</height>
           </size>
          </property>
@@ -85,7 +95,7 @@
         <widget class="QComboBox" name="SortType">
          <property name="minimumSize">
           <size>
-           <width>110</width>
+           <width>100</width>
            <height>0</height>
           </size>
          </property>
@@ -128,7 +138,7 @@
         <widget class="QComboBox" name="ShowType">
          <property name="minimumSize">
           <size>
-           <width>110</width>
+           <width>100</width>
            <height>0</height>
           </size>
          </property>
@@ -150,17 +160,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Sim only</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Big Mods</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Small Mods</string>
+           <string>Sim Only</string>
           </property>
          </item>
          <item>
@@ -173,6 +173,19 @@
            <string>Installed</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelInfo">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Info</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -205,7 +218,7 @@
       </layout>
      </item>
      <item>
-      <widget class="QListWidget" name="modList">
+      <widget class="QListView" name="modList">
        <property name="focusPolicy">
         <enum>Qt::NoFocus</enum>
        </property>
@@ -240,9 +253,6 @@
         <enum>QListView::ListMode</enum>
        </property>
        <property name="uniformItemSizes">
-        <bool>true</bool>
-       </property>
-       <property name="sortingEnabled">
         <bool>true</bool>
        </property>
       </widget>

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -26,6 +26,9 @@ import json
 from model.gameset import Gameset
 from model.player import Player
 from model.playerset import Playerset
+from model.modset import Modset
+from modvault.modmodel import ModModel
+from modvault.moditem import ModViewBuilder
 from modvault.utils import MODFOLDER
 import notifications as ns
 import replays
@@ -152,6 +155,7 @@ class ClientWindow(FormClass, BaseClass):
         self.players = Playerset()  # Players known to the client
 
         self.gameset = Gameset(self.players)
+        self.modset = Modset()
         fa.instance.gameset = self.gameset  # FIXME (needed fa/game_process L81 for self.game = self.gameset[uid])
 
         # Handy reference to the User object representing the logged-in user.
@@ -159,8 +163,8 @@ class ClientWindow(FormClass, BaseClass):
 
         # Qt model for displaying active games.
         self.game_model = GameModel(self.me, self.gameset)
-
-        self.lobby_info = LobbyInfo(self.lobby_dispatch, self.gameset, self.players)
+        self.mod_model = ModModel(self.me, self.modset)
+        self.lobby_info = LobbyInfo(self.lobby_dispatch, self.gameset, self.players, self.modset)
         self.gameset.newGame.connect(self.fill_in_session_info)
 
         self.lobby_dispatch["session"] = self.handle_session
@@ -538,7 +542,9 @@ class ClientWindow(FormClass, BaseClass):
         self.replays = replays.ReplaysWidget(self, self.lobby_dispatch,
                                              self.gameset, self.players)
         self.mapvault = vault.MapVault(self)
-        self.modvault = modvault.ModVault(self)
+        self.modview_builder = ModViewBuilder(self.downloader)
+        self.modvault = modvault.ModVault(self, self.mod_model,
+                                          self.modview_builder)
         self.notificationSystem = ns.Notifications(self, self.gameset,
                                                    self.players, self.me)
 

--- a/src/fa/mods.py
+++ b/src/fa/mods.py
@@ -1,6 +1,6 @@
 from PyQt5 import QtWidgets
 import fa
-import modvault
+from modvault.utils import getInstalledMods, setActiveMods
 import logging
 import config
 
@@ -14,7 +14,7 @@ def checkMods(mods):  # mods is a dictionary of uid-name pairs
     """
     logger.info("Updating FA for mods %s" % ", ".join(mods))
     to_download = []
-    inst = modvault.getInstalledMods()
+    inst = getInstalledMods()
     uids = [mod.uid for mod in inst]
     for uid in mods:
         if uid not in uids:
@@ -43,7 +43,7 @@ def checkMods(mods):  # mods is a dictionary of uid-name pairs
             return False
 
     actual_mods = []
-    inst = modvault.getInstalledMods()
+    inst = getInstalledMods()
     uids = {}
     for mod in inst:
         uids[mod.uid] = mod
@@ -53,7 +53,7 @@ def checkMods(mods):  # mods is a dictionary of uid-name pairs
                                       "%s was apparently not installed correctly. Please check this." % mods[uid])
             return
         actual_mods.append(uids[uid])
-    if not modvault.setActiveMods(actual_mods):
+    if not setActiveMods(actual_mods):
         logger.warning("Couldn't set the active mods in the game.prefs file")
         return False
 

--- a/src/fa/updater.py
+++ b/src/fa/updater.py
@@ -26,7 +26,7 @@ import fafpath
 from PyQt5 import QtWidgets, QtCore, QtNetwork
 
 import util
-import modvault
+from modvault.utils import downloadMod
 
 
 logger = logging.getLogger(__name__)
@@ -523,7 +523,7 @@ class Updater(QtCore.QObject, ConnectionHandler):
                 self.connection.writeToServer("REQUEST_SIM_PATH", self.featured_mod)
                 self.waitForSimModPath()
                 if self.result == self.RESULT_SUCCESS:
-                    if modvault.downloadMod(self.modpath):
+                    if downloadMod(self.modpath):
                         self.connection.writeToServer("ADD_DOWNLOAD_SIM_MOD", self.featured_mod)
 
             else:

--- a/src/model/mod.py
+++ b/src/model/mod.py
@@ -1,0 +1,112 @@
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from decorators import with_logger
+
+
+@with_logger
+class Mod(QObject):
+
+    modUpdated = pyqtSignal(object, object)
+
+    SENTINEL = object()
+
+    def __init__(self, uid, description, version, thumbnail, date, ui, link, played,
+                 author, bugreports, name, downloads, likes, comments):
+
+        QObject.__init__(self)
+
+        self.uid = uid
+        self.description = ""
+        self.version = 0
+        self.thumbnail = None
+        self.date = None
+        self.is_uimod = False
+        self.link = ""
+        self.played = 0
+        self.author = ""
+        self.comments = []  # every element is a dictionary with a
+        self.bugreports = []  # text, author and date key
+        self.name = ""
+        self.downloads = 0
+        self.likes = 0
+
+        self.installed = False
+        self.uploaded_byuser = False
+
+        self._update(uid, description, version, thumbnail, date, ui, link, played,
+                     author, bugreports, name, downloads, likes, comments)
+
+    def copy(self):
+        s = self
+        return Mod(s.uid, s.description, s.version, s.thumbnail, s.date, s.is_uimod, s.link, s.played,
+                   s.author, s.bugreports, s.name, s.downloads, s.likes, s.comments)
+
+    def update(self, *args, **kwargs):
+        old = self.copy()
+        self._update(*args, **kwargs)
+        self.modUpdated.emit(self, old)
+
+    def _update(self,
+                uid=SENTINEL,
+                description=SENTINEL,
+                version=SENTINEL,
+                thumbnail=SENTINEL,
+                date=SENTINEL,
+                ui=SENTINEL,
+                link=SENTINEL,
+                played=SENTINEL,
+                author=SENTINEL,
+                bugreports=SENTINEL,
+                name=SENTINEL,
+                downloads=SENTINEL,
+                likes=SENTINEL,
+                comments=SENTINEL):
+
+        def changed(item):
+            return item is not self.SENTINEL
+
+        if changed(uid):
+            self.uid = uid
+        if changed(name):
+            self.name = name
+        if changed(description):
+            self.description = description
+        if changed(author):
+            self.author = author
+        if changed(version):
+            self.version = version
+        if changed(downloads):
+            self.downloads = downloads
+        if changed(likes):
+            self.likes = likes
+        if changed(played):
+            self.played = played
+        if changed(comments):
+            self.comments = comments
+        if changed(bugreports):
+            self.bugreports = bugreports
+        if changed(date):
+            self.date = date
+        if changed(ui):
+            self.is_uimod = ui
+        if changed(thumbnail):
+            self.thumbnail = thumbnail
+        if changed(link):
+            self.link = link
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "played": self.played,
+            "description": self.description,
+            "version": self.version,
+            "author": self.author,
+            "downloads": self.downloads,
+            "likes": self.likes,
+            "comments": self.comments,
+            "bugreports": self.bugreports,
+            "date": self.date,  # = QtCore.QDateTime.fromSecsSinceEpoch(dic['date': ).toString("yyyy-MM-dd")
+            "ui": self.is_uimod,
+            "link": self.link,  # Direct link to the zip file.
+            "thumbnail": self.thumbstr  # direct url to the thumbnail file.
+        }

--- a/src/model/modset.py
+++ b/src/model/modset.py
@@ -1,0 +1,73 @@
+from PyQt5.QtCore import QObject, pyqtSignal
+from decorators import with_logger
+
+from model import mod
+
+
+@with_logger
+class Modset(QObject):
+
+    newMod = pyqtSignal(object)
+    removedMod = pyqtSignal(object)
+
+    def __init__(self):
+        QObject.__init__(self)
+        self.mods = {}
+
+    def __getitem__(self, uid):
+        return self.mods[uid]
+
+    def __contains__(self, uid):
+        return uid in self.mods
+
+    def __iter__(self):
+        return iter(self.mods)
+
+    def keys(self):
+        return self.mods.keys()
+
+    def values(self):
+        return self.mods.values()
+
+    def items(self):
+        return self.mods.items()
+
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
+    def __setitem__(self, key, value):
+        if not isinstance(key, str) or not isinstance(value, mod.Mod):
+            raise TypeError
+
+        if key in self:
+            raise ValueError
+
+        if key != value.uid:
+            raise ValueError
+
+        self.mods[key] = value
+        # We should be the first ones to connect to the signal
+        value.modUpdated.connect(self._at_mod_update)
+        self._at_mod_update(value, None)
+        self.newMod.emit(value)
+        self._logger.debug("Added mod, uid {}".format(value.uid))
+
+    def clear(self):
+        # Abort_mod removes g from dict, so 'for g in values()' complains
+        for g in list(self.mods.values()):
+            g.abort_mod()
+
+    def _at_mod_update(self, new, old):
+        return
+
+    def _remove_mod(self, mod):
+        try:
+            mod = self.mods[mod.uid]
+            mod.modUpdated.disconnect(self._at_mod_update)
+            del self.mods[mod.uid]
+            self._logger.debug("Removed mod, uid {}".format(mod.uid))
+        except KeyError:
+            pass

--- a/src/modvault/__init__.py
+++ b/src/modvault/__init__.py
@@ -10,20 +10,20 @@ possible commands (value for the 'type' key):
 Can also send a UPLOAD_MOD command directly using writeToServer
 "UPLOAD_MOD","modname.zip",{mod info}, qfile
 
-modInfo function is called when the client recieves a modvault_info command.
+modInfo function is called when the client receives a modvault_info command.
 It should have a message dict with the following keys:
 uid         - Unique identifier for a mod. Also needed ingame.
 name        - Name of the mod. Also the name of the folder the mod will be located in.
 description - A general description of the mod. As seen ingame
 author      - The FAF username of the person that uploaded the mod.
 downloads   - An integer containing the amount of downloads of this mod
-likes       - An integer containing the amount of likes the mod has recieved. #TODO: Actually implement an inteface for this.
+likes       - An integer containing the amount of likes the mod has received. #TODO: Actually implement an inteface for this.
 comments    - A python list containing dictionaries containing the keys as described above.
 bugreports  - A python list containing dictionaries containing the keys as described above.
 date        - A string describing the date the mod was uploaded. Format: "%Y-%m-%d %H:%M:%S" eg: 2012-10-28 16:50:28
 ui          - A boolean describing if it is a ui mod yay or nay.
 link        - Direct link to the zip file containing the mod.
-thumbnail   - A direct link to the thumbnail file. Should be something suitable for util.THEME.icon(). Not yet tested if this works correctly
+thumbnail   - A direct link to the thumbnail file. Should be something suitable for util.THEME.icon().
 
 Additional stuff:
 fa.exe now has a CheckMods method, which is used in fa.exe.check
@@ -35,20 +35,15 @@ handle_game_launch should have a new key in the form of mods, which is a list of
 to be checked with checkMods.
 
 Stuff to be removed:
-In _gameswidget.py in hostGameCLicked setActiveMods is called.
+In hostgamewidget.py in hosting and _launch_game setActiveMods is called.
 This should be done in the faf.exe.check function or in the lobby code.
 It is here because the server doesn't yet send the mods info.
-
-The tempAddMods function should be removed after the server can return mods in the modvault.
 """
 
 import os
-
-import zipfile
-
-from PyQt5 import QtCore, QtWidgets, QtGui
-
-from modvault.utils import *
+from PyQt5 import QtCore, QtWidgets
+from . import utils
+from .modmodel import ModFilterModel
 from .modwidget import ModWidget
 from .uploadwidget import UploadModWidget
 from .uimodwidget import UIModWidget
@@ -56,114 +51,74 @@ from ui.busy_widget import BusyWidget
 
 import util
 import logging
-import time
 logger = logging.getLogger(__name__)
-import urllib.request, urllib.error, urllib.parse
-
-from util import datetostr, now
-d = datetostr(now())
-"""
-tempmod1 = dict(uid=1,name='Mod1', comments=[],bugreports=[], date = d,
-                ui=True, downloads=0, likes=0,
-                thumbnail='',author='johnie102',
-                description='Lorem ipsum dolor sit amet, consectetur adipiscing elit. ',)
-"""
 
 FormClass, BaseClass = util.THEME.loadUiType("modvault/modvault.ui")
 
 
 class ModVault(FormClass, BaseClass, BusyWidget):
-    def __init__(self, client, *args, **kwargs):
-        QtCore.QObject.__init__(self, *args, **kwargs)
 
+    def __init__(self, client, mod_model, modview_builder):
+        BaseClass.__init__(self)
         self.setupUi(self)
 
         self.client = client
 
         logger.debug("Mod Vault tab instantiating")
-        self.loaded = False
+        self._mod_model = ModFilterModel(mod_model)
+        self.modview = modview_builder(self._mod_model, self.modList)
+        self.modview.mod_double_clicked.connect(self.mod_double_clicked)
+        self.modview._delegate.painting.connect(self.info_update)
 
-        self.modList.setItemDelegate(ModItemDelegate(self))
-        self.modList.itemDoubleClicked.connect(self.modClicked)
-        self.searchButton.clicked.connect(self.search)
-        self.searchInput.returnPressed.connect(self.search)
+        self.searchButton.clicked.connect(self.server_search)
+        self.searchInput.returnPressed.connect(self.filter_search)
         self.uploadButton.clicked.connect(self.openUploadForm)
         self.UIButton.clicked.connect(self.openUIModForm)
 
         self.SortType.setCurrentIndex(2)
-        self.SortType.currentIndexChanged.connect(self.sortChanged)
-        self.ShowType.currentIndexChanged.connect(self.showChanged)
+        self.SortType.currentIndexChanged.connect(self.sort_changed)
+        self.ShowType.currentIndexChanged.connect(self.show_changed)
 
-        self.client.lobby_info.modVaultInfo.connect(self.modInfo)
-
-        self.sortType = "rating"
         self.showType = "all"
-        self.searchString = ""
 
-        self.mods = {}
-        self.uids = [mod.uid for mod in getInstalledMods()]
-
-    @QtCore.pyqtSlot(dict)
-    def modInfo(self, message):  # this is called when the database has send a mod to us
-        """
-        See above for the keys neccessary in message.
-        """
-        uid = message["uid"]
-        if not uid in self.mods:
-            mod = ModItem(self, uid)
-            self.mods[uid] = mod
-            self.modList.addItem(mod)
-        else:
-            mod = self.mods[uid]
-        mod.update(message)
-        self.modList.sortItems(1)
+        self.uids = [mod.uid for mod in utils.getInstalledMods()]
 
     @QtCore.pyqtSlot(int)
-    def sortChanged(self, index):
-        if index == -1 or index == 0:
-            self.sortType = "alphabetical"
-        elif index == 1:
-            self.sortType = "date"
-        elif index == 2:
-            self.sortType = "rating"
-        elif index == 3:
-            self.sortType = "downloads"
-        self.updateVisibilities()
+    def sort_changed(self, index):
+        self._mod_model.sort_type = ModFilterModel.SortType(index)
 
     @QtCore.pyqtSlot(int)
-    def showChanged(self, index):
-        if index == -1 or index == 0:
-            self.showType = "all"
-        elif index == 1:
-            self.showType = "ui"
-        elif index == 2:
-            self.showType = "sim"
-        elif index == 5:
-            self.showType = "yours"
-        elif index == 6:
-            self.showType = "installed"
-        self.updateVisibilities()
+    def show_changed(self, index):
+        self._mod_model.filter_type = ModFilterModel.FilterType(index)
+        self.info_update()  # in case search returns nothing
 
-    @QtCore.pyqtSlot(QtWidgets.QListWidgetItem)
-    def modClicked(self, item):
-        widget = ModWidget(self, item)
+    def mod_double_clicked(self, mod):
+        widget = ModWidget(self, mod)
         widget.exec_()
 
-    def search(self):
+    def info_update(self):
+        self.labelInfo.setText("showing {} of {} mods / {} installed mods".
+                               format(self._mod_model.rowCount(), len(self.client.modset.mods), len(self.uids)))
+
+    def server_search(self):
         """ Sending search to mod server"""
-
-        self.searchString = self.searchInput.text().lower()
+        search_str = self.searchInput.text().lower()
+        self._mod_model.search_str = search_str
         index = self.ShowType.currentIndex()
-        typemod = 2
-
-        if index == 1:
+        if index == 1:  # UI Only
             typemod = 1
-        elif index == 2:
+        elif index == 2:  # Sim Only
             typemod = 0
+        else:  # All, yours, installed
+            typemod = 2
 
-        self.client.statsServer.send(dict(command="modvault_search", typemod=typemod, search=self.searchString))
+        self.client.statsServer.send(dict(command="modvault_search", typemod=typemod, search=search_str))
 
-        self.updateVisibilities()
+    def filter_search(self):
+        """ filter mods with search string"""
+        search_str = self.searchInput.text().lower()
+        self._mod_model.search_str = search_str
+        self.info_update()  # in case search returns nothing
 
     @QtCore.pyqtSlot()
     def openUIModForm(self):
@@ -173,15 +128,15 @@ class ModVault(FormClass, BaseClass, BusyWidget):
     @QtCore.pyqtSlot()
     def openUploadForm(self):
         modDir = QtWidgets.QFileDialog.getExistingDirectory(self.client, "Select the mod directory to upload",
-                                                            MODFOLDER,  QtWidgets.QFileDialog.ShowDirsOnly)
+                                                            utils.MODFOLDER,  QtWidgets.QFileDialog.ShowDirsOnly)
         logger.debug("Uploading mod from: " + modDir)
         if modDir != "":
-            if isModFolderValid(modDir):
+            if utils.isModFolderValid(modDir):
                 # os.chmod(modDir, S_IWRITE) Don't need this at the moment
-                modinfofile, modinfo = parseModInfo(modDir)
+                modinfofile, modinfo = utils.parseModInfo(modDir)
                 if modinfofile.error:
-                    logger.debug("There were " + str(modinfofile.errors) + " errors and " + str(modinfofile.warnings) +
-                                 " warnings.")
+                    logger.debug("There were " + str(modinfofile.errors) + " errors and " +
+                                 str(modinfofile.warnings) + " warnings.")
                     logger.debug(modinfofile.errorMsg)
                     QtWidgets.QMessageBox.critical(self.client, "Lua parsing error", modinfofile.errorMsg +
                                                    "\nMod uploading cancelled.")
@@ -194,7 +149,7 @@ class ModVault(FormClass, BaseClass, BusyWidget):
                     else:
                         uploadmod = QtWidgets.QMessageBox.Yes
                     if uploadmod == QtWidgets.QMessageBox.Yes:
-                        modinfo = ModInfo(**modinfo)
+                        modinfo = utils.ModInfo(**modinfo)
                         modinfo.setFolder(os.path.split(modDir)[1])
                         modinfo.update()
                         dialog = UploadModWidget(self, modDir, modinfo)
@@ -207,211 +162,16 @@ class ModVault(FormClass, BaseClass, BusyWidget):
     def busy_entered(self):
         self.client.lobby_connection.send(dict(command="modvault", type="start"))
 
-    def updateVisibilities(self):
-        logger.debug("Updating visibilities with sort '%s' and visibility '%s'" % (self.sortType, self.showType))
-        for mod in self.mods:
-            self.mods[mod].updateVisibility()
-        self.modList.sortItems(1)
-
-    def downloadMod(self, mod):
-        if downloadMod(mod):
+    def download_mod(self, mod):
+        if utils.downloadMod(mod):
             self.client.lobby_connection.send(dict(command="modvault", type="download", uid=mod.uid))
-            self.uids = [mod.uid for mod in getInstalledMods()]
-            self.updateVisibilities()
+            self.uids = [mod.uid for mod in utils.getInstalledMods()]
+            mod.installed = mod.uid in self.uids
             return True
         else:
             return False
 
-    def removeMod(self, mod):
-        if removeMod(mod):
-            self.uids = [m.uid for m in installedMods]
-            mod.updateVisibility()
-
-
-# the drawing helper function for the modlist
-class ModItemDelegate(QtWidgets.QStyledItemDelegate):
-
-    def __init__(self, *args, **kwargs):
-        QtWidgets.QStyledItemDelegate.__init__(self, *args, **kwargs)
-
-    def paint(self, painter, option, index, *args, **kwargs):
-        self.initStyleOption(option, index)
-
-        painter.save()
-
-        html = QtGui.QTextDocument()
-        html.setHtml(option.text)
-
-        icon = QtGui.QIcon(option.icon)
-        iconsize = icon.actualSize(option.rect.size())
-
-        # clear icon and text before letting the control draw itself because we're rendering these parts ourselves
-        option.icon = QtGui.QIcon()
-        option.text = ""  
-        option.widget.style().drawControl(QtWidgets.QStyle.CE_ItemViewItem, option, painter, option.widget)
-
-        # Shadow
-        painter.fillRect(option.rect.left()+8-1, option.rect.top()+8-1, iconsize.width(), iconsize.height(), QtGui.QColor("#202020"))
-
-        # Icon
-        icon.paint(painter, option.rect.adjusted(5-2, -2, 0, 0), QtCore.Qt.AlignLeft|QtCore.Qt.AlignVCenter)
-
-        # Frame around the icon
-        pen = QtGui.QPen()
-        pen.setWidth(1)
-        pen.setBrush(QtGui.QColor("#303030"))  # FIXME: This needs to come from theme.
-        pen.setCapStyle(QtCore.Qt.RoundCap)
-        painter.setPen(pen)
-        painter.drawRect(option.rect.left()+5-2, option.rect.top()+3, iconsize.width(), iconsize.height())
-
-        # Description
-        painter.translate(option.rect.left() + iconsize.width() + 10, option.rect.top()+4)
-        clip = QtCore.QRectF(0, 0, option.rect.width()-iconsize.width() - 10 - 5, option.rect.height())
-        html.drawContents(painter, clip)
-
-        painter.restore()
-
-    def sizeHint(self, option, index, *args, **kwargs):
-        self.initStyleOption(option, index)
-
-        html = QtGui.QTextDocument()
-        html.setHtml(option.text)
-        html.setTextWidth(ModItem.TEXTWIDTH)
-        return QtCore.QSize(ModItem.ICONSIZE + ModItem.TEXTWIDTH + ModItem.PADDING, ModItem.ICONSIZE + ModItem.PADDING)   
-
-
-class ModItem(QtWidgets.QListWidgetItem):
-    TEXTWIDTH = 230
-    ICONSIZE = 100
-    PADDING = 10
-    
-    WIDTH = ICONSIZE + TEXTWIDTH
-    #DATA_PLAYERS = 32
-
-    FORMATTER_MOD = str(util.THEME.readfile("modvault/modinfo.qthtml"))
-    FORMATTER_MOD_UI = str(util.THEME.readfile("modvault/modinfoui.qthtml"))
-
-    def __init__(self, parent, uid, *args, **kwargs):
-        QtWidgets.QListWidgetItem.__init__(self, *args, **kwargs)
-
-        self.parent = parent
-        self.uid = uid
-        self.name = ""
-        self.description = ""
-        self.author = ""
-        self.version = 0
-        self.downloads = 0
-        self.likes = 0
-        self.played = 0
-        self.comments = []  # every element is a dictionary with a
-        self.bugreports = []  # text, author and date key
-        self.date = None
-        self.isuidmod = False
-        self.uploadedbyuser = False
-
-        self.thumbnail = None
-        self.link = ""
-        self.loadThread = None
-        self.setHidden(True)
-
-    def update(self, dic):
-        self.name = dic["name"]
-        self.played = dic["played"]
-        self.description = dic["description"]
-        self.version = dic["version"]
-        self.author = dic["author"]
-        self.downloads = dic["downloads"]
-        self.likes = dic["likes"]
-        self.comments = dic["comments"]
-        self.bugreports = dic["bugreports"]
-        self.date = QtCore.QDateTime.fromTime_t(dic['date']).toString("yyyy-MM-dd")
-        self.isuimod = dic["ui"]
-        self.link = dic["link"]  # Direct link to the zip file.
-        self.thumbstr = dic["thumbnail"]  # direct url to the thumbnail file.
-        self.uploadedbyuser = (self.author == self.parent.client.login)
-
-        self.thumbnail = None
-        if self.thumbstr == "":
-            self.setIcon(util.THEME.icon("games/unknown_map.png"))
-        else:
-            name = os.path.basename(urllib.parse.unquote(self.thumbstr))
-            img = getIcon(name)
-            if img:
-                self.setIcon(util.THEME.icon(img, False))
-            else:
-                self.parent.client.downloader.downloadModPreview(self.thumbstr, name, self)
-        self.updateVisibility()
-
-    def updateIcon(self):
-        self.setIcon(self.thumbnail)
-
-    def shouldBeVisible(self):
-        p = self.parent
-        if p.searchString != "":
-            if not (self.author.lower().find(p.searchString) != -1 or self.name.lower().find(p.searchString) != -1 or
-                            self.description.lower().find(" " + p.searchString + " ") != -1):
-                return False
-        if p.showType == "all":
-            return True
-        elif p.showType == "ui":
-            return self.isuimod
-        elif p.showType == "sim":
-            return not self.isuimod
-        elif p.showType == "yours":
-            return self.uploadedbyuser
-        elif p.showType == "installed":
-            return self.uid in self.parent.uids
-        else:  # shouldn't happen
-            return True
-
-    def updateVisibility(self):
-        self.setHidden(not self.shouldBeVisible())
-        if len(self.description) < 200:
-            descr = self.description
-        else:
-            descr = self.description[:197] + "..."
-
-        modtype = ""
-        if self.isuimod:
-            modtype = "UI mod"
-        if self.uid in self.parent.uids:
-            color = "green"
-        else:
-            color = "white"
-
-        if self.isuimod:
-            self.setText(self.FORMATTER_MOD_UI.format(color=color, version=str(self.version), title=self.name,
-                                                      description=descr, author=self.author,
-                                                      downloads=str(self.downloads), likes=str(self.likes),
-                                                      date=str(self.date), modtype=modtype))
-        else:
-            self.setText(self.FORMATTER_MOD.format(color=color, version=str(self.version), title=self.name,
-                                                   description=descr, author=self.author, downloads=str(self.downloads),
-                                                   likes=str(self.likes), date=str(self.date), modtype=modtype,
-                                                   played=str(self.played)))
-
-        self.setToolTip('<p width="230">%s</p>' % self.description)
-
-    def __ge__(self, other):
-        return not self.__lt__(self, other)
-
-    def __lt__(self, other):
-        if self.parent.sortType == "alphabetical":
-            if self.name.lower() == other.name.lower():
-                return self.uid < other.uid
-            return self.name.lower() > other.name.lower()
-        elif self.parent.sortType == "rating":
-            if self.likes == other.likes:
-                return self.downloads < other.downloads
-            return self.likes < other.likes
-        elif self.parent.sortType == "downloads":
-            if self.downloads == other.downloads:
-                return self.date < other.date
-            return self.downloads < other.downloads
-        elif self.parent.sortType == "date":
-            # guard
-            if self.date is None:
-                return other.date is not None
-            if self.date == other.date:
-                return self.name.lower() < other.name.lower()
-            return self.date < other.date
+    def remove_mod(self, mod):
+        if utils.removeMod(mod):
+            self.uids = [m.uid for m in utils.installedMods]
+            mod.installed = mod.uid in self.uids

--- a/src/modvault/moditem.py
+++ b/src/modvault/moditem.py
@@ -1,0 +1,214 @@
+from PyQt5 import QtCore, QtWidgets, QtGui
+from downloadManager import IconCallback
+import os
+import util
+import urllib.parse
+
+
+class ModView(QtCore.QObject):
+    """
+    Helps with displaying mods in the mod widget. Handles updates to view
+    unrelated to underlying data, like downloading mod previews. Forwards
+    interaction with the view.
+    """
+    mod_double_clicked = QtCore.pyqtSignal(object)
+
+    def __init__(self, model, view, delegate, dler):
+        QtCore.QObject.__init__(self)
+        self._model = model
+        self._view = view
+        self._delegate = delegate
+        self._dler = dler
+
+        self._view.setModel(self._model)
+        self._view.setItemDelegate(self._delegate)
+        self._delegate.mod_preview_missing.connect(self.download_mod_preview)
+        self._view.doubleClicked.connect(self._mod_double_clicked)
+        self._view.viewport().installEventFilter(self._delegate.tooltip_filter)
+
+    def download_mod_preview(self, mod):
+        name = os.path.basename(urllib.parse.unquote(mod.thumbnail))
+        cb = IconCallback(name, self._mod_preview_downloaded)
+        self._dler.downloadModPreview(mod.thumbnail, name, cb)  # (url, name, requester)
+
+    # TODO make it a utility function?
+    def _model_items(self):
+        model = self._model
+        for i in range(model.rowCount(QtCore.QModelIndex())):
+            yield model.index(i, 0)
+
+    def _mod_preview_downloaded(self, modname, icon):
+        for idx in self._model_items():
+            mod = idx.data().mod
+            if mod.thumbnail != "":
+                name = os.path.basename(urllib.parse.unquote(mod.thumbnail))
+                if name.lower() == modname.lower():  # Previews are not case-preserving
+                    self._view.update(idx)
+
+    def _mod_double_clicked(self, idx):
+        self.mod_double_clicked.emit(idx.data().mod)
+
+
+class ModItemDelegate(QtWidgets.QStyledItemDelegate):
+    mod_preview_missing = QtCore.pyqtSignal(object)
+    painting = QtCore.pyqtSignal()
+
+    ICON_RECT = 100
+    ICON_CLIP_TOP_LEFT = 3
+    ICON_CLIP_BOTTOM_RIGHT = -7
+    ICON_SHADOW_OFFSET = 8
+    SHADOW_COLOR = QtGui.QColor("#202020")
+    FRAME_THICKNESS = 1
+    FRAME_COLOR = QtGui.QColor("#303030")
+    TEXT_OFFSET = 10
+    TEXT_RIGHT_MARGIN = 5
+
+    TEXT_WIDTH = 250
+    ICON_SIZE = 110
+    PADDING = 10
+
+    def __init__(self, formatter):
+        QtWidgets.QStyledItemDelegate.__init__(self)
+        self._formatter = formatter
+        self.tooltip_filter = ModTooltipFilter(self._formatter)
+
+    def paint(self, painter, option, index):
+        painter.save()
+
+        data = index.data()
+        text = self._formatter.text(data)
+        icon = self._formatter.icon(data)
+
+        self._check_mod_preview(data)
+
+        self._draw_clear_option(painter, option)
+        self._draw_icon_shadow(painter, option)
+        self._draw_icon(painter, option, icon)
+        self._draw_frame(painter, option)
+        self._draw_text(painter, option, text)
+
+        painter.restore()
+        self.painting.emit()
+
+    def _check_mod_preview(self, data):
+        needed_preview = self._formatter.needed_mod_preview(data)  # mod or None
+        if needed_preview:
+            self.mod_preview_missing.emit(data.mod)
+
+    @staticmethod
+    def _draw_clear_option(painter, option):
+        option.icon = QtGui.QIcon()
+        option.text = ""
+        option.widget.style().drawControl(QtWidgets.QStyle.CE_ItemViewItem,
+                                          option, painter, option.widget)
+
+    def _draw_icon_shadow(self, painter, option):
+        painter.fillRect(option.rect.left() + self.ICON_SHADOW_OFFSET,
+                         option.rect.top() + self.ICON_SHADOW_OFFSET,
+                         self.ICON_RECT, self.ICON_RECT, self.SHADOW_COLOR)
+
+    def _draw_icon(self, painter, option, icon):
+        rect = option.rect.adjusted(self.ICON_CLIP_TOP_LEFT, self.ICON_CLIP_TOP_LEFT,
+                                    self.ICON_CLIP_BOTTOM_RIGHT, self.ICON_CLIP_BOTTOM_RIGHT)
+        icon.paint(painter, rect, QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
+
+    def _draw_frame(self, painter, option):
+        pen = QtGui.QPen()
+        pen.setWidth(self.FRAME_THICKNESS)
+        pen.setBrush(self.FRAME_COLOR)
+        pen.setCapStyle(QtCore.Qt.RoundCap)
+        painter.setPen(pen)
+        painter.drawRect(option.rect.left() + self.ICON_CLIP_TOP_LEFT,
+                         option.rect.top() + self.ICON_CLIP_TOP_LEFT,
+                         self.ICON_RECT, self.ICON_RECT)
+
+    def _draw_text(self, painter, option, text):
+        left_off = self.ICON_RECT + self.TEXT_OFFSET
+        top_off = 0  # self.TEXT_OFFSET
+        right_off = self.TEXT_RIGHT_MARGIN
+        bottom_off = 0
+        painter.translate(option.rect.left() + left_off, option.rect.top() + top_off)
+        clip = QtCore.QRectF(0, 0,
+                             option.rect.width() - left_off - right_off,
+                             option.rect.height() - top_off - bottom_off)
+        html = QtGui.QTextDocument()
+        html.setHtml(text)
+        html.drawContents(painter, clip)
+
+    def sizeHint(self, option, index):
+        return QtCore.QSize(self.ICON_SIZE + self.TEXT_WIDTH + self.PADDING, self.ICON_SIZE)
+
+
+class ModTooltipFilter(QtCore.QObject):
+    def __init__(self, formatter):
+        QtCore.QObject.__init__(self)
+        self._formatter = formatter
+
+    def eventFilter(self, obj, event):
+        if event.type() == QtCore.QEvent.ToolTip:
+            return self._handle_tooltip(obj, event)
+        else:
+            return super().eventFilter(obj, event)
+
+    def _handle_tooltip(self, widget, event):
+        view = widget.parent()
+        idx = view.indexAt(event.pos())
+        if not idx.isValid():
+            return False
+
+        tooltip_text = self._formatter.tooltip(idx.data())
+        QtWidgets.QToolTip.showText(event.globalPos(), tooltip_text, widget)
+        return True
+
+
+class ModItemFormatter:
+    FORMATTER_MOD = str(util.THEME.readfile("modvault/modinfo.qthtml"))
+    FORMATTER_MOD_UI = str(util.THEME.readfile("modvault/modinfoui.qthtml"))
+
+    def __init__(self):
+        return
+
+    def text(self, data):
+        mod = data.mod
+        descr = mod.description if len(mod.description) < 175 else mod.description[:172] + "..."
+
+        formatting = {
+            "color": "limegreen" if mod.installed else "white",
+            "version": mod.version,
+            "title": mod.name,
+            "description": descr,
+            "author": mod.author,
+            "downloads": mod.downloads,
+            "played": mod.played,
+            "likes": int(mod.likes),
+            "date": QtCore.QDateTime.fromSecsSinceEpoch(mod.date, 0).toString("yyyy-MM-dd"),
+            "modtype": "UI mod" if mod.is_uimod else ""
+        }
+
+        if mod.is_uimod:
+            return self.FORMATTER_MOD_UI.format(**formatting)
+        else:
+            return self.FORMATTER_MOD.format(**formatting)
+
+    @staticmethod
+    def icon(data):
+        return data.mod_icon
+
+    @staticmethod
+    def needed_mod_preview(data):
+        return data.mod_icon is None
+
+    @staticmethod
+    def tooltip(data):
+        return '<p width="230">{}</p>'.format(data.mod.description)
+
+
+class ModViewBuilder:
+    def __init__(self, preview_dler):
+        self._preview_dler = preview_dler
+
+    def __call__(self, model, view):
+        mod_formatter = ModItemFormatter()
+        mod_delegate = ModItemDelegate(mod_formatter)
+        modview = ModView(model, view, mod_delegate, self._preview_dler)
+        return modview

--- a/src/modvault/modmodel.py
+++ b/src/modvault/modmodel.py
@@ -1,0 +1,187 @@
+from PyQt5.QtCore import QAbstractListModel, Qt, QSortFilterProxyModel, QModelIndex
+from .modmodelitem import ModModelItem
+from enum import Enum
+
+
+class ModModel(QAbstractListModel):
+    def __init__(self, me, modset=None):
+        QAbstractListModel.__init__(self)
+        self._me = me
+        self._moditems = {}
+        self._itemlist = []  # For queries
+
+        self._modset = modset
+        if self._modset is not None:
+            self._modset.newMod.connect(self.add_mod)
+            self._modset.removedMod.connect(self.remove_mod)
+
+            for mod in self._modset.values():
+                self.add_mod(mod)
+
+    def rowCount(self, parent):
+        if parent.isValid():
+            return 0
+        return len(self._itemlist)
+
+    def data(self, index, role):
+        if not index.isValid() or index.row() >= len(self._itemlist):
+            return None
+        if role != Qt.DisplayRole:
+            return None
+        return self._itemlist[index.row()]
+
+    def add_mod(self, mod):
+        assert mod.uid not in self._moditems
+
+        next_index = len(self._itemlist)
+        self.beginInsertRows(QModelIndex(), next_index, next_index)
+
+        item = ModModelItem(mod, self._me)
+        item.mmI_updated.connect(self._at_item_updated)
+
+        self._moditems[mod.uid] = item
+        self._itemlist.append(item)
+
+        self.endInsertRows()
+
+    def remove_mod(self, mod):
+        assert mod.uid in self._moditems
+
+        item = self._moditems[mod.uid]
+        item_index = self._itemlist.index(item)
+        self.beginRemoveRows(QModelIndex(), item_index, item_index)
+
+        item.mmI_updated.disconnect(self._at_item_updated)
+        del self._moditems[mod.uid]
+        self._itemlist.pop(item_index)
+        self.endRemoveRows()
+
+    def _at_item_updated(self, item):
+        item_index = self._itemlist.index(item)
+        index = self.index(item_index, 0)
+        self.dataChanged.emit(index, index)
+
+
+class ModSortModel(QSortFilterProxyModel):
+    class SortType(Enum):
+        ALPHABETICAL = 0
+        DATE = 1
+        RATING = 2
+        DOWNLOADS = 3
+
+    def __init__(self, model):
+        QSortFilterProxyModel.__init__(self)
+        self._sort_type = self.SortType.RATING
+        self.setSourceModel(model)
+        self.sort(0)
+
+    def lessThan(self, left_index, right_index):
+        left = self.sourceModel().data(left_index, Qt.DisplayRole).mod
+        right = self.sourceModel().data(right_index, Qt.DisplayRole).mod
+
+        comp_list = [self._lt_type, self._lt_fallback]
+
+        for lt in comp_list:
+            if lt(left, right):
+                return True
+            elif lt(right, left):
+                return False
+        return False
+
+    def _lt_type(self, left, right):
+        stype = self._sort_type
+        stypes = self.SortType
+
+        if stype == stypes.ALPHABETICAL:
+            if left.name.lower() == right.name.lower():
+                return left.version > right.version
+            return left.name.lower() < right.name.lower()
+        elif stype == stypes.DATE:
+            if left.date == right.date:
+                return left.name.lower() < right.name.lower()
+            return left.date > right.date
+        elif stype == stypes.RATING:
+            if left.likes == right.likes:
+                return left.date > right.date
+            return left.likes > right.likes
+        elif stype == stypes.DOWNLOADS:
+            if left.downloads == right.downloads:
+                return left.date > right.date
+            return left.downloads > right.downloads
+
+    @staticmethod
+    def _lt_fallback(left, right):
+        return left.uid < right.uid
+
+    @property
+    def sort_type(self):
+        return self._sort_type
+
+    @sort_type.setter
+    def sort_type(self, stype):
+        self._sort_type = stype
+        self.invalidate()
+
+    def filterAcceptsRow(self, row, parent):
+        index = self.sourceModel().index(row, 0, parent)
+        if not index.isValid():
+            return False
+        mod = index.data().mod
+
+        return self.filter_accepts_mod(mod)
+
+    def filter_accepts_mod(self, mod):
+        return True
+
+
+class ModFilterModel(ModSortModel):
+    class FilterType(Enum):
+        ALL = 0
+        UI = 1
+        SIM = 2
+        YOURS = 3
+        INSTALLED = 4
+
+    def __init__(self, model):
+        self._filter_type = self.FilterType.ALL
+        self._search_str = ""
+        ModSortModel.__init__(self, model)
+
+    def filter_accepts_mod(self, mod):
+        search_str = self._search_str
+        if search_str != "":
+            if not (mod.author.lower().find(search_str) != -1 or mod.name.lower().find(search_str) != -1 or
+                    mod.description.lower().find(search_str) != -1):
+                return False
+        ftype = self._filter_type
+        ftypes = self.FilterType
+        if ftype == ftypes.ALL:
+            return True
+        elif ftype == ftypes.UI:
+            return mod.is_uimod
+        elif ftype == ftypes.SIM:
+            return not mod.is_uimod
+        elif ftype == ftypes.YOURS:
+            return mod.uploaded_byuser
+        elif ftype == ftypes.INSTALLED:
+            return mod.installed
+
+        return True
+
+    @property
+    def filter_type(self):
+        return self._filter_type
+
+    @filter_type.setter
+    def filter_type(self, ftype):
+        self._filter_type = ftype
+        self.invalidateFilter()
+
+    @property
+    def search_str(self):
+        return self._search_str
+
+    @search_str.setter
+    def search_str(self, sstr):
+        self._search_str = sstr
+        self.invalidateFilter()

--- a/src/modvault/modmodelitem.py
+++ b/src/modvault/modmodelitem.py
@@ -1,0 +1,35 @@
+from PyQt5.QtCore import QObject, pyqtSignal
+from modvault.utils import getIcon, installedMods
+import urllib.parse
+import os
+import util
+
+
+class ModModelItem(QObject):
+    """
+    UI representation of a mod.
+    """
+    mmI_updated = pyqtSignal(object)
+
+    def __init__(self, mod, me):
+        QObject.__init__(self)
+
+        self.mod = mod
+        self.mod.modUpdated.connect(self._mod_updated)
+        self._me = me
+        self._uids = [mod.uid for mod in installedMods]
+        if mod.thumbnail == "":
+            self.mod_icon = util.THEME.icon("games/unknown_map.png")
+        else:
+            name = os.path.basename(urllib.parse.unquote(mod.thumbnail))
+            img = getIcon(name)
+            if img:  # in cache
+                self.mod_icon = util.THEME.icon(img, False)
+            else:  # should be downloaded
+                self.mod_icon = util.THEME.icon("games/private_game.png")
+        mod.thumbnail = self.mod_icon
+        mod.installed = mod.uid in self._uids
+        mod.uploaded_byuser = (mod.author == self._me.login)
+
+    def _mod_updated(self):
+        self.mmI_updated.emit(self)

--- a/src/modvault/modwidget.py
+++ b/src/modvault/modwidget.py
@@ -1,9 +1,4 @@
-
-import urllib.request, urllib.error, urllib.parse
-
-from PyQt5 import QtCore, QtWidgets, QtGui
-
-from util import strtodate, datetostr, now
+from PyQt5 import QtCore, QtWidgets
 import util
 
 FormClass, BaseClass = util.THEME.loadUiType("modvault/mod.ui")
@@ -24,35 +19,18 @@ class ModWidget(FormClass, BaseClass):
 
         self.Title.setText(mod.name)
         self.Description.setText(mod.description)
-        modtext = ""
-        if mod.isuimod: modtext = "UI mod\n"
-        self.Info.setText(modtext + "By %s\nUploaded %s" % (mod.author, str(mod.date)))
+        modtext = "UI mod\n" if mod.is_uimod else ""
+        self.Info.setText("{}By {}\nUploaded {}".format(modtext, mod.author, mod.date))
         if mod.thumbnail is None:
             self.Picture.setPixmap(util.THEME.pixmap("games/unknown_map.png"))
-        else:
+        elif not isinstance(mod.thumbnail, str):
             self.Picture.setPixmap(mod.thumbnail.pixmap(100, 100))
-
-        #self.Comments.setItemDelegate(CommentItemDelegate(self))
-        #self.BugReports.setItemDelegate(CommentItemDelegate(self))
 
         self.tabWidget.setEnabled(False)
 
         if self.mod.uid in self.parent.uids:
             self.DownloadButton.setText("Remove Mod")
         self.DownloadButton.clicked.connect(self.download)
-
-        #self.likeButton.clicked.connect(self.like)
-        #self.LineComment.returnPressed.connect(self.addComment)
-        #self.LineBugReport.returnPressed.connect(self.addBugReport)
-
-        #for item in mod.comments:
-        #    comment = CommentItem(self,item["uid"])
-        #    comment.update(item)
-        #    self.Comments.addItem(comment)
-        #for item in mod.bugreports:
-        #    comment = CommentItem(self,item["uid"])
-        #    comment.update(item)
-        #    self.BugReports.addItem(comment)
 
         self.likeButton.setEnabled(False)
         self.LineComment.setEnabled(False)
@@ -61,108 +39,12 @@ class ModWidget(FormClass, BaseClass):
     @QtCore.pyqtSlot()
     def download(self):
         if self.mod.uid not in self.parent.uids:
-            self.parent.downloadMod(self.mod)
+            self.parent.download_mod(self.mod)
             self.done(1)
         else:
             show = QtWidgets.QMessageBox.question(self.parent.client, "Delete Mod",
                                                   "Are you sure you want to delete this mod?",
                                                   QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
             if show == QtWidgets.QMessageBox.Yes:
-                self.parent.removeMod(self.mod)
+                self.parent.remove_mod(self.mod)
                 self.done(1)
-
-    @QtCore.pyqtSlot()
-    def addComment(self):
-        if self.LineComment.text() == "":
-            return
-        comment = {"author": self.parent.client.login, "text": self.LineComment.text(),
-                   "date": datetostr(now()), "uid": "%s-%s" % (self.mod.uid, str(len(self.mod.bugreports) +
-                                                                                 len(self.mod.comments)).zfill(3))}
-
-        self.parent.client.lobby_connection.send(dict(command="modvault", type="addcomment", moduid=self.mod.uid,
-                                                      comment=comment))
-        c = CommentItem(self, comment["uid"])
-        c.update(comment)
-        self.Comments.addItem(c)
-        self.mod.comments.append(comment)
-        self.LineComment.setText("")
-
-    @QtCore.pyqtSlot()
-    def addBugReport(self):
-        if self.LineBugReport.text() == "":
-            return
-        bugreport = {"author": self.parent.client.login, "text": self.LineBugReport.text(),
-                     "date": datetostr(now()), "uid": "%s-%s" % (self.mod.uid, str(len(self.mod.bugreports) +
-                                                                                   len(self.mod.comments)).zfill(3))}
-
-        self.parent.client.lobby_connection.send(dict(command="modvault", type="addbugreport", moduid=self.mod.uid,
-                                                      bugreport=bugreport))
-        c = CommentItem(self, bugreport["uid"])
-        c.update(bugreport)
-        self.BugReports.addItem(c)
-        self.mod.bugreports.append(bugreport)
-        self.LineBugReport.setText("")
-
-    @QtCore.pyqtSlot()
-    def like(self):  # the server should determine if the user hasn't already clicked the like button for this mod.
-        self.parent.client.lobby_connection.send(dict(command="modvault", type="like", uid=self.mod.uid))
-        self.likeButton.setEnabled(False)
-
-
-class CommentItemDelegate(QtWidgets.QStyledItemDelegate):
-    TEXTWIDTH = 350
-    TEXTHEIGHT = 60
-
-    def __init__(self, *args, **kwargs):
-        QtWidgets.QStyledItemDelegate.__init__(self, *args, **kwargs)
-
-    def paint(self, painter, option, index, *args, **kwargs):
-        self.initStyleOption(option, index)
-
-        painter.save()
-
-        html = QtGui.QTextDocument()
-        html.setHtml(option.text)
-
-        option.text = ""  
-        option.widget.style().drawControl(QtWidgets.QStyle.CE_ItemViewItem, option, painter, option.widget)
-
-        # Description
-        painter.translate(option.rect.left() + 10, option.rect.top()+10)
-        clip = QtCore.QRectF(0, 0, option.rect.width(), option.rect.height())
-        html.drawContents(painter, clip)
-
-        painter.restore()
-
-    def sizeHint(self, option, index, *args, **kwargs):
-        self.initStyleOption(option, index)
-
-        html = QtGui.QTextDocument()
-        html.setHtml(option.text)
-        html.setTextWidth(self.TEXTWIDTH)
-        return QtCore.QSize(self.TEXTWIDTH, self.TEXTHEIGHT)
-
-
-class CommentItem(QtWidgets.QListWidgetItem):
-    FORMATTER_COMMENT = str(util.THEME.readfile("modvault/comment.qthtml"))
-
-    def __init__(self, parent, uid, *args, **kwargs):
-        QtWidgets.QListWidgetItem.__init__(self, *args, **kwargs)
-
-        self.parent = parent
-        self.uid = uid
-        self.text = ""
-        self.author = ""
-        self.date = None
-
-    def update(self, dic):
-        self.text = dic["text"]
-        self.author = dic["author"]
-        self.date = strtodate(dic["date"])
-        self.setText(self.FORMATTER_COMMENT.format(text=self.text, author=self.author, date=str(self.date)))
-
-    def __ge__(self, other):
-        return self.date > other.date
-
-    def __lt__(self, other):
-        return self.date <= other.date

--- a/src/modvault/uimodwidget.py
+++ b/src/modvault/uimodwidget.py
@@ -1,9 +1,6 @@
-
-import urllib.request, urllib.error, urllib.parse
-
 from PyQt5 import QtCore, QtWidgets
 
-import modvault
+from modvault.utils import getInstalledMods, getActiveMods, setActiveMods
 import util
 
 FormClass, BaseClass = util.THEME.loadUiType("modvault/uimod.ui")
@@ -24,14 +21,14 @@ class UIModWidget(FormClass, BaseClass):
 
         self.doneButton.clicked.connect(self.doneClicked)
         self.modList.itemEntered.connect(self.hoverOver)
-        allmods = modvault.getInstalledMods()
+        allmods = getInstalledMods()
         self.uimods = {}
         for mod in allmods:
             if mod.ui_only:
                 self.uimods[mod.totalname] = mod
                 self.modList.addItem(mod.totalname)
 
-        names = [mod.totalname for mod in modvault.getActiveMods(uimods=True)]
+        names = [mod.totalname for mod in getActiveMods(uimods=True)]
         for name in names:
             l = self.modList.findItems(name, QtCore.Qt.MatchExactly)
             if l:
@@ -43,7 +40,7 @@ class UIModWidget(FormClass, BaseClass):
     @QtCore.pyqtSlot()
     def doneClicked(self):
         selected_mods = [self.uimods[str(item.text())] for item in self.modList.selectedItems()]
-        succes = modvault.setActiveMods(selected_mods, False)
+        succes = setActiveMods(selected_mods, False)
         if not succes:
             QtWidgets.QMessageBox.information(None, "Error", "Could not set the active UI mods. Maybe something is "
                                                              "wrong with your game.prefs file. Please send your log.")

--- a/src/modvault/uploadwidget.py
+++ b/src/modvault/uploadwidget.py
@@ -1,11 +1,10 @@
-import urllib.request, urllib.error, urllib.parse
+from PyQt5 import QtCore, QtWidgets
+
 import tempfile
 import zipfile
 import os
 
-from PyQt5 import QtCore, QtWidgets
-
-import modvault
+from modvault import utils
 import util
 
 FormClass, BaseClass = util.THEME.loadUiType("modvault/upload.ui")
@@ -34,7 +33,7 @@ class UploadModWidget(FormClass, BaseClass):
         self.UID.setText(modinfo.uid)
         self.Description.setPlainText(modinfo.description)
         if modinfo.icon != "":
-            self.IconURI.setText(modvault.iconPathToFull(modinfo.icon))
+            self.IconURI.setText(utils.iconPathToFull(modinfo.icon))
             self.updateThumbnail()
         else:
             self.Thumbnail.setPixmap(util.THEME.pixmap("games/unknown_map.png"))
@@ -48,11 +47,11 @@ class UploadModWidget(FormClass, BaseClass):
                                               "The mod name contains invalid characters: /\\<>|?:\"")
             return
 
-        iconpath = modvault.iconPathToFull(self.modinfo.icon)
+        iconpath = utils.iconPathToFull(self.modinfo.icon)
         infolder = False
         if iconpath != "" and os.path.commonprefix([os.path.normcase(self.modDir), os.path.normcase(iconpath)]) == \
                 os.path.normcase(self.modDir):  # the icon is in the game folder
-            localpath = modvault.fullPathToIcon(iconpath)
+            localpath = utils.fullPathToIcon(iconpath)
             infolder = True
         if iconpath != "" and not infolder:
             QtWidgets.QMessageBox.information(self.client, "Invalid Icon File",
@@ -76,13 +75,13 @@ class UploadModWidget(FormClass, BaseClass):
 
     @QtCore.pyqtSlot()
     def updateThumbnail(self):
-        iconfilename = modvault.iconPathToFull(self.modinfo.icon)
+        iconfilename = utils.iconPathToFull(self.modinfo.icon)
         if iconfilename == "":
             return False
         if os.path.splitext(iconfilename)[1].lower() == ".dds":
             old = iconfilename
             iconfilename = os.path.join(self.modDir, os.path.splitext(os.path.basename(iconfilename))[0] + ".png")
-            succes = modvault.generateThumbnail(old, iconfilename)
+            succes = utils.generateThumbnail(old, iconfilename)
             if not succes:
                 QtWidgets.QMessageBox.information(self.client, "Invalid Icon File",
                                                   "Because FAF can't read DDS files, it tried to convert it to a png. "
@@ -94,7 +93,7 @@ class UploadModWidget(FormClass, BaseClass):
             QtWidgets.QMessageBox.information(self.client, "Invalid Icon File",
                                               "This was not a valid icon file. Please pick a png or jpeg")
             return False
-        self.modinfo.thumbnail = modvault.fullPathToIcon(iconfilename)
+        self.modinfo.thumbnail = utils.fullPathToIcon(iconfilename)
         self.IconURI.setText(iconfilename)
         return True
 

--- a/src/modvault/utils.py
+++ b/src/modvault/utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import urllib.request, urllib.error, urllib.parse
 import re
 import shutil
@@ -10,13 +9,10 @@ from util import PREFSFILENAME
 import util
 import logging
 from vault import luaparser
-import warnings
 
-import io
 import zipfile
 from config import Settings
-from downloadManager import FileDownload
-from vault.dialogs import VaultDownloadDialog, downloadVaultAsset
+from vault.dialogs import downloadVaultAsset
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
change modvault into QListView (analog to Game)
separate functions for filter and server-search
add an explain text for the rather odd behavior
reorder some imports

remarks:
1. if the icon fetching in modmodelitem is ok (separate func?), we could loose the complete preview part in moditem.
2. a signal is needed to call update_info after a View update. not sure how.