### PR TITLE
Enable Qt ANGLE workaround by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
  * Don't proceed with game launch if FA path is invalid (#933, #959)
  * Hotfix an irclib exception popping up in some cases (#958)
  * Delay displaying of user's ladder game info until launch (#360, #912)
+ * Use the more compatible ANGLE renderer by default (#963)
 
 Contributors:
  - Wesmania

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -35,9 +35,13 @@ import argparse
 cmd_parser = argparse.ArgumentParser(description='FAF client commandline arguments.')
 cmd_parser.add_argument('--qt-angle-workaround',
                         action='store_true',
-                        help='Use Qt5 ANGLE backend. Enable if some client tabs appear frozen.')
+                        help='Use Qt5 ANGLE backend. Enable if some client tabs appear frozen. On by default.')
+cmd_parser.add_argument('--no-qt-angle-workaround',
+                        action='store_true',
+                        help='Do not use Qt5 ANGLE backend.')
+
 args, trailing_args = cmd_parser.parse_known_args()
-if args.qt_angle_workaround and sys.platform == 'win32':
+if sys.platform == 'win32' and not args.no_qt_angle_workaround:
     os.environ.setdefault('QT_OPENGL', 'angle')
     os.environ.setdefault('QT_ANGLE_PLATFORM', 'd3d9')
 


### PR DESCRIPTION
This is an issue for quite a few people, and there don't seem to be
downsides to turning it on. To avoid new players dropping the client the
moment it doesn't work, let's keep it on by default.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Thank you for contributing to this project! Please set a good title for your PR and  replace this line with a (preferrably multi-line) description of your PR.

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [ ] PR branch should be named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [ ] Code is split into logical commits
- [ ] Code has tests
- [ ] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with your PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section
