### PR TITLE
Don't connect signals' emit to signals directly

### DIFF
--- a/src/client/user.py
+++ b/src/client/user.py
@@ -98,13 +98,19 @@ class User(QtCore.QObject):
 
         self._friends = UserRelation()
         self._foes = UserRelation()
-        self._friends.updated.connect(self.relationsUpdated.emit)
-        self._foes.updated.connect(self.relationsUpdated.emit)
+        self._friends.updated.connect(self._relations_updated)
+        self._foes.updated.connect(self._relations_updated)
 
         self._irc_friends = IrcUserRelation()
         self._irc_foes = IrcUserRelation()
-        self._irc_friends.updated.connect(self.ircRelationsUpdated.emit)
-        self._irc_foes.updated.connect(self.ircRelationsUpdated.emit)
+        self._irc_friends.updated.connect(self._irc_relations_updated)
+        self._irc_foes.updated.connect(self._irc_relations_updated)
+
+    def _relations_updated(self, items):
+        self.relationsUpdated.emit(items)
+
+    def _irc_relations_updated(self, items):
+        self.ircRelationsUpdated.emit(items)
 
     @property
     def player(self):


### PR DESCRIPTION
Apparently these cause PyQt to crash after a couple emits.

Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>