### PR TITLE
Log qt messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
    - At first run, checks system UI language on Windows and LANG on unix. If no
      matching channel is found, uses user's geoIP.
    - Language channels to join configurable through settings.
+ * Log qt messages to FAF client log, silence some noisier messages.
 
  Contributors:
  - Wesmania

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -262,3 +262,23 @@ if Settings.get('client/logs/console', False, type=bool):
 
 logging.getLogger().info("FAF version: {} Environment: {}".format(
     VERSION, environment))
+
+
+def qt_log_handler(type_, context, text):
+    loglvl = None
+    if type_ == QtCore.QtDebugMsg:
+        loglvl = logging.DEBUG
+    elif type_ == QtCore.QtInfoMsg:
+        loglvl = logging.INFO
+    elif type_ == QtCore.QtWarningMsg:
+        loglvl = logging.WARNING
+    elif type_ == QtCore.QtCriticalMsg:
+        loglvl = logging.ERROR
+    elif type_ == QtCore.QtFatalMsg:
+        loglvl = logging.CRITICAL
+    if loglvl is None:
+        return
+    logging.getLogger().log(loglvl, "Qt: " + text)
+
+
+QtCore.qInstallMessageHandler(qt_log_handler)

--- a/src/downloadManager/__init__.py
+++ b/src/downloadManager/__init__.py
@@ -58,7 +58,7 @@ class FileDownload(QObject):
         # check status code
         statusCode = self._dfile.attribute(QNetworkRequest.HttpStatusCodeAttribute)
         if statusCode != 200:
-            logger.warning('Download failed: %s -> %s', self.addr, statusCode)
+            logger.debug('Download failed: %s -> %s', self.addr, statusCode)
             self.error = True
         self.finished.emit(self)
 
@@ -162,7 +162,7 @@ class PreviewDownload(QtCore.QObject):
 
     def _finished(self, dl):
         dl.dest.close()
-        logger.info("Finished download from " + dl.addr)
+        logger.debug("Finished download from " + dl.addr)
         if self.failed():
             logger.debug("Web Preview failed for: {}".format(self.name))
             os.unlink(dl.destpath)


### PR DESCRIPTION
PyQt5 calls qFatal() when an uncaught Python exception percolates to Qt code. I suspect this is a cause for some client crashes, so let's log these messages.