### PR TITLE
make replayserver port dynamic

### DIFF
--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -12,8 +12,6 @@ logger = logging.getLogger(__name__)
 # Initialize all important globals
 LOBBY_HOST = Settings.get('lobby/host')
 LOBBY_PORT = Settings.get('lobby/port')
-LOCAL_REPLAY_PORT = Settings.get('lobby/relay/port')
-
 
 class ClientState(IntEnum):
     """

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -3,7 +3,7 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 import config
 import connectivity
 from connectivity.helper import ConnectivityHelper
-from client import ClientState, LOBBY_HOST, LOBBY_PORT, LOCAL_REPLAY_PORT
+from client import ClientState, LOBBY_HOST, LOBBY_PORT
 from client.aliasviewer import AliasWindow, AliasSearchWindow
 from client.connection import LobbyInfo, ServerConnection, \
         Dispatcher, ConnectionState, ServerReconnecter
@@ -1164,7 +1164,7 @@ class ClientWindow(FormClass, BaseClass):
             pass
 
     def doConnect(self):
-        if not self.replayServer.doListen(LOCAL_REPLAY_PORT):
+        if not self.replayServer.doListen():
             return False
 
         self.lobby_connection.doConnect()
@@ -1516,7 +1516,7 @@ class ClientWindow(FormClass, BaseClass):
 
         self.game_session.game_uid = message['uid']
 
-        fa.run(info, self.game_session.relay_port, arguments, self.game_session.game_uid)
+        fa.run(info, self.game_session.relay_port, self.replayServer.serverPort(), arguments, self.game_session.game_uid)
 
     def fill_in_session_info(self, game):
         # sometimes we get the game_info message before a game session was created

--- a/src/config/production.py
+++ b/src/config/production.py
@@ -27,7 +27,6 @@ defaults = {
     'host': 'faforever.com',
     'proxy/host': 'proxy.{host}',
     'proxy/port': 9124,
-    'lobby/relay/port': 15000,
     'lobby/host': 'lobby.{host}',
     'lobby/port': 8001,
     'mordor/host': 'http://mordor.{host}',

--- a/src/fa/play.py
+++ b/src/fa/play.py
@@ -9,7 +9,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def build_argument_list(game_info, port, arguments=None, log_suffix=None):
+def build_argument_list(game_info, port, replayPort, arguments=None, log_suffix=None):
     """
     Compiles an argument list to run the game with POpen style process invocation methods.
     Extends a potentially pre-existing argument list to allow for injection of special parameters
@@ -42,7 +42,7 @@ def build_argument_list(game_info, port, arguments=None, log_suffix=None):
 
     # live replay
     arguments.append('/savereplay')
-    arguments.append('"gpgnet://localhost/' + str(game_info['uid']) + "/" + str(game_info['recorder']) + '.SCFAreplay"')
+    arguments.append('"gpgnet://localhost:' + str(replayPort) + '/' + str(game_info['uid']) + "/" + str(game_info['recorder']) + '.SCFAreplay"')
 
     # gpg server emulation
     arguments.append('/gpgnet 127.0.0.1:' + str(port))
@@ -50,10 +50,10 @@ def build_argument_list(game_info, port, arguments=None, log_suffix=None):
     return arguments
 
 
-def run(game_info, port, arguments=None, log_suffix=None):
+def run(game_info, port, replayPort, arguments=None, log_suffix=None):
     """
     Launches Forged Alliance with the given arguments
     """
     logger.info("Play received arguments: %s" % arguments)
-    arguments = build_argument_list(game_info, port, arguments, log_suffix)
+    arguments = build_argument_list(game_info, port, replayPort, arguments, log_suffix)
     return instance.run(game_info, arguments)

--- a/src/fa/replayserver.py
+++ b/src/fa/replayserver.py
@@ -149,20 +149,20 @@ class ReplayServer(QtNetwork.QTcpServer):
         self.__logger.debug("initializing...")
         self.newConnection.connect(self.acceptConnection)
 
-    def doListen(self,local_port):
+    def doListen(self):
         while not self.isListening():
-            self.listen(QtNetwork.QHostAddress.LocalHost, local_port)
+            self.listen(QtNetwork.QHostAddress.LocalHost, 0)
             if self.isListening():
                 self.__logger.info("listening on address " + self.serverAddress().toString() + ":" + str(self.serverPort()))
             else:
-                self.__logger.error("cannot listen, port probably used by another application: " + str(local_port))
+                self.__logger.error("cannot listen, port probably used by another application: " + str(self.serverPort()))
                 answer = QtWidgets.QMessageBox.warning(None, "Port Occupied", "FAF couldn't start its local replay "
                                                                               "server, which is needed to play Forged "
                                                                               "Alliance online. Possible reasons:<ul>"
                                                                               "<li><b>FAF is already running</b> (most "
                                                                               "likely)</li><li>another program is "
                                                                               "listening on port {port}</li></ul>"
-                                                       .format(port=local_port),
+                                                       .format(port=self.serverPort()),
                                                        QtWidgets.QMessageBox.Retry, QtWidgets.QMessageBox.Abort)
                 if answer == QtWidgets.QMessageBox.Abort:
                     return False


### PR DESCRIPTION
I'm annoyed by the "Port Occupied" message when starting the client a second time. This should fix it.