### PR TITLE
Use skewed ladder rating when matchmaking newbies

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1525,7 +1525,7 @@ class ClientWindow(FormClass, BaseClass):
             show = False
             for q in message['queues']:
                 if q['queue_name'] == 'ladder1v1':
-                    mu = self.me.player.ladder_rating_mean
+                    mu = self.me.player.ladder_rating_newbie_adjusted_mean
                     for min, max in q[key]:
                         if min < mu < max:
                             show = True

--- a/src/model/player.py
+++ b/src/model/player.py
@@ -91,6 +91,17 @@ class Player(ModelItem):
         return self.ladder_rating[0]
 
     @property
+    def ladder_rating_newbie_adjusted_mean(self):
+        GAMES_TILL_NOT_NEWBIE = 30
+        mean = self.ladder_rating_mean
+        games = self.number_of_games
+        if games >= GAMES_TILL_NOT_NEWBIE:
+            return mean
+        else:
+            # Weighted average between real rating and 0
+            return (mean * games) / GAMES_TILL_NOT_NEWBIE
+
+    @property
     def ladder_rating_deviation(self):
         return self.ladder_rating[1]
 


### PR DESCRIPTION
Signed-off-by: Igor Kotrasinski <ikotrasinsk@gmail.com>

Skew ladder ratings of newbie players towards 0 - this way, instead of losing 20 times in a row at the beginning, they can win at least some 10 games in their first 50. Skewed ratings affect choice of player for matchmaking, not actual rating calculations.