### PR TITLE
feature - add Nomads support to coop

### DIFF
--- a/src/coop/coopmodel.py
+++ b/src/coop/coopmodel.py
@@ -9,6 +9,6 @@ class CoopGameFilterModel(GameSortModel):
     def filter_accepts_game(self, game):
         if game.state != GameState.OPEN:
             return False
-        if game.featured_mod != "coop":
+        if game.featured_mod != ("coop" or "nomadscoop"):
             return False
         return True

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -71,7 +71,7 @@ class GameLauncher:
         # Ensure all mods are up-to-date, and abort if the update process fails.
         if not fa.check.check(game.featured_mod):
             return
-        if (game.featured_mod == "coop"
+        if (game.featured_mod == ("coop" or "nomadscoop")
            and not fa.check.map_(game.mapname, force=True)):
             return
 
@@ -125,7 +125,7 @@ class HostGameWidget(FormClass, BaseClass):
 
         i = 0
         index = 0
-        if game.featured_mod != "coop":
+        if game.featured_mod != ("coop" or "nomadscoop"):
             allmaps = {}
             for map_ in list(maps.maps.keys()) + maps.getUserMaps():
                 allmaps[map_] = maps.getDisplayName(map_)
@@ -195,7 +195,7 @@ class HostGameWidget(FormClass, BaseClass):
 
     def save_last_hosted_settings(self, password):
         util.settings.beginGroup("fa.games")
-        if self.game.featured_mod != "coop":
+        if self.game.featured_mod != ("coop" or "nomadscoop"):
             util.settings.setValue("gamemap", self.game.mapname)
         util.settings.setValue("gamename", self.game.title)
         util.settings.setValue("friends_only", self.radioFriends.isChecked())


### PR DESCRIPTION
i have no idea what im doing.

this pr is supposed to enable the coop tab to be able to support nomads missions, which need their own featured mod to work, since they also have to load the nomads mod on top of the coop mod, and then another nomads coop mod on top of that. since the client only supports coop with the "coop" featured mod, it needs to be changed to not just that.

this also requires the nomads coop mod to be uploaded onto the server and added as a featured mod of the right type, but that bit isnt relevant to this repo specifically.

again, i am completely incompetent. and i have no idea what im doing. partly this is to make someone who can actually do work more motivated xD