### PR TITLE
Fix - Get featured mod info from API instead of lobby server

### DIFF
--- a/src/api/ApiBase.py
+++ b/src/api/ApiBase.py
@@ -31,7 +31,7 @@ class ApiBase(QtCore.QObject):
 
     def onRequestFinished(self, reply):
         if reply.error() != QtNetwork.QNetworkReply.NoError:
-            logger.error("API request error:", reply.error())
+            logger.error("API request error: %s", reply.error())
         else:
             message_bytes = reply.readAll().data()
             message = json.loads(message_bytes.decode('utf-8'))
@@ -89,4 +89,3 @@ class ApiBase(QtCore.QObject):
         except:
             logger.error("error parsing ", data)
         return result
-

--- a/src/api/featured_mod_api.py
+++ b/src/api/featured_mod_api.py
@@ -1,0 +1,23 @@
+from .ApiBase import ApiBase
+import logging
+logger = logging.getLogger(__name__)
+
+class FeaturedModApiConnector(ApiBase):
+    def __init__(self, dispatch):
+        ApiBase.__init__(self, '/data/featuredMod')
+        self.dispatch = dispatch
+
+    def requestData(self):
+        self.request({}, self.handleData)
+
+    def handleData(self, message):
+        for mod in message:
+            preparedData = {
+                "command": "mod_info_api",
+                "name": mod["technicalName"],
+                "fullname": mod["displayName"],
+                "publish": mod.get("visible", False),
+                "order": mod.get("order", 0),
+                "desc": mod.get("description", "<i>No description provided</i>")
+            }
+            self.dispatch.dispatch(preparedData)

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -351,7 +351,8 @@ class LobbyInfo(QtCore.QObject):
         self._dispatcher["stats"] = self._simple_emit(self.statsInfo)
         self._dispatcher["coop_info"] = self._simple_emit(self.coopInfo)
         self._dispatcher["tutorials_info"] = self._simple_emit(self.tutorialsInfo)
-        self._dispatcher["mod_info"] = self._simple_emit(self.modInfo)
+        self._dispatcher["mod_info_api"] = self._simple_emit(self.modInfo)
+        self._dispatcher["mod_info"] = lambda _: None
         self._dispatcher["game_info"] = self.handle_game_info
         self._dispatcher["modvault_list_info"] = self.handle_modvault_list_info
         self._dispatcher["modvault_info"] = self._simple_emit(self.modVaultInfo)

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -6,6 +6,7 @@ from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtCore import QUrl, pyqtSlot
 
 import util
+from api.featured_mod_api import FeaturedModApiConnector
 from config import Settings
 from games.moditem import ModItem, mod_invisible
 from games.gamemodel import CustomGameFilterModel
@@ -37,6 +38,8 @@ class GamesWidget(FormClass, BaseClass):
         self.mods = {}
         self._game_model = CustomGameFilterModel(self._me, game_model)
         self._game_launcher = game_launcher
+
+        self.apiConnector = FeaturedModApiConnector(self.client.lobby_dispatch)
 
         self.gameview = gameview_builder(self._game_model, self.gameList)
         self.gameview.game_double_clicked.connect(self.gameDoubleClicked)
@@ -88,6 +91,7 @@ class GamesWidget(FormClass, BaseClass):
         self.modList.itemDoubleClicked.connect(self.hostGameClicked)
 
         self.updatePlayButton()
+        self.apiConnector.requestData()
 
     @pyqtSlot(dict)
     def processModInfo(self, message):


### PR DESCRIPTION
I want to remove the server message that sends featured mod info as the official client already pulls this info from the API. This PR adds that same functionality.

Please let me know if I need to move code around, add tests or anything else.