### PR TITLE
Add advanced login parameters

### DIFF
--- a/res/client/client.css
+++ b/res/client/client.css
@@ -1,5 +1,5 @@
 
- *[warning="true"]
+*[warning="true"]
 {
     color:lightgrey;
     font-size:8pt;
@@ -20,6 +20,8 @@
     height: 18px;
 
 }
+
+/* Menu items */
 
 QMenuBar
 {
@@ -79,6 +81,7 @@ QMenuBar::item
      height: 13px;
  }
 
+/* Tab widgets */
 
 QTabWidget #lobbyTab,#gamesTab,#ladderTab,#tournamentTab,#coopTab,#replaysTab,#vaultsTab,#mapsTab,#modsTab
 { /* sets background color for every widget under a tab */
@@ -155,11 +158,11 @@ QTabWidget#topTabs::pane
  }
 
 
- QTabWidget#topTabs::tab-bar
+QTabWidget#topTabs::tab-bar
 {
     top: 0px;
     left: 25px; /* move to the right by 25px */
- }
+}
 
 
 /* Style the tab using the tab sub-control. Note that it reads QTabBar _not_ QTabWidget */
@@ -197,6 +200,8 @@ QTabWidget#topTabs > QTabBar::tab:selected
 
 }
 
+/* Splitters */
+
 QSplitter::handle
 {
     background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #0F0F0F, stop:1 #2f2f2f);
@@ -217,7 +222,141 @@ QSplitter::handle:vertical
 QSplitter::handle:hover
 {
      background-color: #606060;
+}
+
+/* Inputs */
+
+QPushButton, QLineEdit, QComboBox {
+  	color: silver;
+    font: bold 12px;
+    padding: 2px;
+  	border: 1px solid rgb(70, 70, 70);
+    min-height: 20px;
+    background-color: rgb(39, 39, 45);
+}
+
+
+QCheckBox#hideGamesWithPw
+{
+    color:white;
+    background-color: #111111;
+}
+
+QLabel#labelSortGames,#labelJoinGame,#labelHostGame,#labelAutomatch,#labelMyReplays,#labelLiveReplays,#labelHostTournament,#labelJoinTournament,#joinLabel,#labelTeamManagement
+{
+    color:white;
+}
+
+QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
+{
+    color:#AAAAAA;
+}
+
+QLabel#titleLabel
+{
+    color:black;
+    font-weight:bold;
+}
+
+QGroupBox
+{
+    margin: 5px;
+    border: 1px solid #353535;
+    border-radius: 5px;
+    background-color: rgb(32, 32, 37);
+    color: silver;
+    padding: 5px;
+    padding-top: 15px;
+}
+
+QLabel
+{
+    color: silver;
+}
+
+/* Used for dialogs*/
+QDialog
+{
+    background-color: #575656;
+}
+
+QCheckBox#spoilerCheckbox, #automaticCheckbox, #showLatestCheckbox, #hideUnrCheckbox
+{
+    color: silver;
+}
+QCheckBox#spoilerCheckbox::indicator:unchecked, #automaticCheckbox::indicator:unchecked, #showLatestCheckbox::indicator:unchecked,
+#hideUnrCheckbox::indicator:unchecked
+{
+    image: url('%THEMEPATH%/client/chboxUncheked.png');
  }
+
+QCheckBox#spoilerCheckbox::indicator:checked, #automaticCheckbox::indicator:checked, #showLatestCheckbox::indicator:checked,
+#hideUnrCheckbox::indicator:checked
+{
+    image: url('%THEMEPATH%/client/chboxCheked.png');
+ }
+
+/* Used for Ranked Buttons only at the moment*/
+QToolButton#rankedPlay
+{
+	color: silver;
+	border-radius: 5px;
+	border: 1px solid grey;
+}
+QToolButton#laddermapspool
+{
+	color: silver;
+	border-radius: 5px;
+	border: 1px solid grey;
+}
+
+QToolButton::pressed
+{
+    border: none;
+    color: black;
+    padding:5px;
+    background-color:#383838;
+    border-radius : 5px;
+}
+
+QToolButton::hover
+{
+    border: none;
+
+    color:silver;
+    padding:5px;
+    background-color:#808080;
+    border-radius : 5px;
+ }
+
+QToolButton::checked
+{
+    border: none;
+    border: 2px solid #353535;
+
+    color:black;
+    padding:5px;
+    background-color:#C0C0C0;
+    border-radius : 5px;
+}
+
+QPushButton#searchButton, #advSearchButton
+{
+  	border: 2px;
+    font: bold 12px;
+}
+
+QPushButton#RefreshResetButton, #advResetButton
+{
+    font: 11px;
+}
+
+
+QComboBox QAbstractItemView {
+    border: 2px solid darkgray;
+    selection-background-color: #575656;
+    background-color: #575656;
+}
 
 QSpinBox#minRating, QLineEdit#mapName, #playerName, QDateEdit#dateEnd, #dateStart, QSpinBox#quantity, #advQuantity,
 QComboBox#modList, #value1, #value2, #value3, #value4, #value5, #value6
@@ -226,7 +365,7 @@ QComboBox#modList, #value1, #value2, #value3, #value4, #value5, #value6
     color: orange;
 }
 
-QComboBox#filter1, #filter2, #filter3, #filter4, #filter5, #filter6, 
+QComboBox#filter1, #filter2, #filter3, #filter4, #filter5, #filter6,
 #operator1, #operator2, #operator3, #operator4, #operator5, #operator6
 {
     background-color: #353535;
@@ -243,7 +382,7 @@ QToolBox#replayToolBox::tab
     color: silver;
     border-radius: 3px;
     padding-left: 145px; /* "alignment: center" doesn't work with toolboxes :| */
-} 
+}
 
 #advancedSearch, #mapPreview
 {
@@ -260,10 +399,6 @@ QTextEdit, QPlainTextEdit, QLineEdit, QListWidget, QListView, QTableWidget, QTre
     padding:5px;
     background-color:#202025;
     alternate-background-color: #303035;
-    border-top-right-radius : 5px;
-    border-top-left-radius : 5px;
-    border-bottom-left-radius : 5px;
-    border-bottom-right-radius : 5px;
 }
 
 /* used in ConnectivityDialog */
@@ -316,15 +451,6 @@ QTableWidget::item:selected, QListWidget::item:previously-selected, QListView::i
 {
     border: none;
 }
-
-
-
-
-QLineEdit
-{
-    color:orange;
-}
-
 
 
 QListWidget::item:hover, QListView::item:hover
@@ -461,144 +587,4 @@ QScrollBar::add-page
 QScrollBar::sub-page
 {
     background-color: #1f1f1f;
-}
-
-QCheckBox#hideGamesWithPw
-{
-    color:white;
-    background-color: #111111;
-}
-
-QLabel#labelSortGames,#labelJoinGame,#labelHostGame,#labelAutomatch,#labelMyReplays,#labelLiveReplays,#labelHostTournament,#labelJoinTournament,#joinLabel,#labelTeamManagement
-{
-    color:white;
-}
-
-QLabel#labelModHint,#labelMyHint,#labelLiveHint,#labelRankedHint,#labelTeamManagementHint,#labelTeamManagementHint2,#labelTeamManagementHint3
-{
-    color:#AAAAAA;
-}
-
-QLabel#titleLabel
-{
-    color:black;
-    font-weight:bold;
-}
-
-QGroupBox
-{
-    margin: 5px;
-    border: 1px solid #353535;
-    border-radius: 5px;
-    background-color: rgb(32, 32, 37);
-    color: silver;
-    padding: 5px;
-    padding-top: 15px;
-}
-
-QLabel
-{
-    color: silver;
-}
-
-/* Used for dialogs*/
-QDialog
-{
-    background-color: #575656;
-}
-
-QCheckBox#spoilerCheckbox, #automaticCheckbox, #showLatestCheckbox, #hideUnrCheckbox
-{
-    color: silver;
-}
-QCheckBox#spoilerCheckbox::indicator:unchecked, #automaticCheckbox::indicator:unchecked, #showLatestCheckbox::indicator:unchecked, 
-#hideUnrCheckbox::indicator:unchecked
-{
-    image: url('%THEMEPATH%/client/chboxUncheked.png');
- }
-
-QCheckBox#spoilerCheckbox::indicator:checked, #automaticCheckbox::indicator:checked, #showLatestCheckbox::indicator:checked, 
-#hideUnrCheckbox::indicator:checked
-{
-    image: url('%THEMEPATH%/client/chboxCheked.png');
- }
-
-/* Used for Ranked Buttons only at the moment*/
-QToolButton#rankedPlay
-{
-	color: silver;
-	border-radius: 5px;
-	border: 1px solid grey;
-}
-QToolButton#laddermapspool
-{
-	color: silver;
-	border-radius: 5px;
-	border: 1px solid grey;
-}
-
-QToolButton::pressed
-{
-    border: none;
-    color: black;
-    padding:5px;
-    background-color:#383838;
-    border-radius : 5px;
-}
-
-QToolButton::hover
-{
-    border: none;
-
-    color:silver;
-    padding:5px;
-    background-color:#808080;
-    border-radius : 5px;
- }
-
-QToolButton::checked
-{
-    border: none;
-    border: 2px solid #353535;
-
-    color:black;
-    padding:5px;
-    background-color:#C0C0C0;
-    border-radius : 5px;
- }
- 
-QPushButton#searchButton, #advSearchButton
-{
-	color: silver;
-	border-radius: 5px;
-	border: 2px solid rgb(70, 70, 70);
-    font: bold 12px;
-    min-height: 20px;
-    background-color: rgb(39, 39, 45);
-}
-
-QPushButton#RefreshResetButton, #advResetButton
-{
-	color: silver;
-	border-radius: 5px;
-	border: 1px solid rgb(70, 70, 70);
-    font: 11px;
-    min-height: 20px;
-    background-color: rgb(39, 39, 45);
-}
-
-QComboBox, QComboBox:selected
-{
-    color:orange;
-    selection-color:orange;
-    background-color: #575656;
-    selection-background-color: #575656;
-}
-
-
-
-QComboBox QAbstractItemView {
-    border: 2px solid darkgray;
-    selection-background-color: #575656;
-    background-color: #575656;
 }

--- a/res/client/login.css
+++ b/res/client/login.css
@@ -1,4 +1,0 @@
-QWidget#header
-{
-    background-color: rgba(255,255,255,255);
-}

--- a/res/client/login.ui
+++ b/res/client/login.ui
@@ -226,6 +226,52 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="extraOptionsToggle">
+           <property name="text">
+            <string>Advanced</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+           <widget class="QFrame" name="extraOptionsFrame">
+            <property name="hidden">
+             <bool>true</bool>
+            </property>
+             <layout class="QGridLayout" name="extraOptionsLayout" columnstretch="3, 1">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="margin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLineEdit" name="hostField">
+                 <property name="placeholderText">
+                  <string>Host</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLineEdit" name="portField">
+                 <property name="placeholderText">
+                  <string>Port</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0" colspan="2">
+                <widget class="QLineEdit" name="apiURLField">
+                 <property name="placeholderText">
+                  <string>API URL</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0" colspan="2">
+                 <widget class="QComboBox" name="environmentBox"></widget>
+               </item>
+             </layout>
+           </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="rememberCheckbox">
            <property name="text">
             <string>Remember me</string>
@@ -343,6 +389,9 @@
  <tabstops>
   <tabstop>loginField</tabstop>
   <tabstop>passwordField</tabstop>
+  <tabstop>hostField</tabstop>
+  <tabstop>portField</tabstop>
+  <tabstop>apiURLField</tabstop>
   <tabstop>loginButton</tabstop>
   <tabstop>quitButton</tabstop>
   <tabstop>rememberCheckbox</tabstop>
@@ -352,6 +401,7 @@
   <tabstop>forgotPasswordButton</tabstop>
   <tabstop>bugreportButton</tabstop>
   <tabstop>stayOfflineButton</tabstop>
+  <tabstop>extraOptionsToggle</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -370,6 +420,18 @@
      <y>253</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>extraOptionsToggle</sender>
+   <signal>released()</signal>
+   <receiver>Dialog</receiver>
+   <slot>on_toggle_extra_options()</slot>
+  </connection>
+  <connection>
+   <sender>environmentBox</sender>
+   <signal>currentIndexChanged()</signal>
+   <receiver>Dialog</receiver>
+   <slot>on_fill_extra_options()</slot>
   </connection>
   <connection>
    <sender>steamLinkButton</sender>

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -102,8 +102,8 @@ def run_faf():
 
     faf_client = client.instance
     faf_client.setup()
+    faf_client.show_login()
     faf_client.show()
-    faf_client.do_connect()
 
     # Main update loop
     QtWidgets.QApplication.exec_()

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1379,7 +1379,7 @@ class ClientWindow(FormClass, BaseClass):
     def handle_authentication_failed(self, message):
         QtWidgets.QMessageBox.warning(self, "Authentication failed", message["text"])
         self._auto_relogin = False
-        self.get_creds_and_login()
+        self.show_login_widget()
 
     def handle_notice(self, message):
         if "text" in message:

--- a/src/client/connection.py
+++ b/src/client/connection.py
@@ -145,7 +145,7 @@ class ServerConnection(QtCore.QObject):
     disconnected = QtCore.pyqtSignal()
     received_pong = QtCore.pyqtSignal()
 
-    def __init__(self, host, port, dispatch):
+    def __init__(self, dispatch):
         QtCore.QObject.__init__(self)
         self.socket = QtNetwork.QTcpSocket()
         self.socket.readyRead.connect(self.readFromServer)
@@ -153,8 +153,6 @@ class ServerConnection(QtCore.QObject):
         self.socket.setSocketOption(QtNetwork.QTcpSocket.KeepAliveOption, 1)
         self.socket.stateChanged.connect(self.on_socket_state_change)
 
-        self._host = host
-        self._port = port
         self._state = ConnectionState.INITIAL
         self.blockSize = 0
         self._disconnect_requested = False
@@ -190,10 +188,10 @@ class ServerConnection(QtCore.QObject):
         self._state = value
         self.state_changed.emit(value)
 
-    def do_connect(self):
+    def do_connect(self, host, port):
         self._disconnect_requested = False
         self.state = ConnectionState.CONNECTING
-        self.socket.connectToHost(self._host, self._port)
+        self.socket.connectToHost(host, port)
 
     def on_connecting(self):
         self.state = ConnectionState.CONNECTING

--- a/src/client/login.py
+++ b/src/client/login.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtCore, QtGui
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 import util
 from config import Settings
@@ -7,14 +7,30 @@ FormClass, BaseClass = util.THEME.loadUiType("client/login.ui")
 
 
 class LoginWidget(FormClass, BaseClass):
-    finished = QtCore.pyqtSignal(str, str)
+    finished = QtCore.pyqtSignal(str, str, str, int, str)
     request_quit = QtCore.pyqtSignal()
     remember = QtCore.pyqtSignal(bool)
 
-    def __init__(self, startLogin=None, remember=False):
+    # TODO: Extract to JSON file
+    environments = {
+        "main": {
+            "display": "Main Server (recommended)",
+            "host": "lobby.faforever.com",
+            "port": 8001,
+            "api_url": "https://api.faforever.com"
+        },
+        "test": {
+            "display": "Test Server",
+            "host": "lobby.test.faforever.com",
+            "port": 8001,
+            "api_url": "http://api.test.faforever.com"
+        }
+    }
+
+    def __init__(self, parent, startLogin=None, remember=False):
         # TODO - init with the parent to inherit the stylesheet
         # once we make some of our own css to go with it
-        BaseClass.__init__(self)
+        BaseClass.__init__(self, parent)
         self.setupUi(self)
         util.THEME.stylesheets_reloaded.connect(self.load_stylesheet)
         self.load_stylesheet()
@@ -23,17 +39,41 @@ class LoginWidget(FormClass, BaseClass):
         if startLogin:
             self.loginField.setText(startLogin)
         self.rememberCheckbox.setChecked(remember)
+        self.portField.setValidator(QtGui.QIntValidator(1, 65535))
+        self.populateEnvironments()
 
     def load_stylesheet(self):
         self.setStyleSheet(util.THEME.readstylesheet("client/login.css"))
+
+    def populateEnvironments(self):
+        for k, env in self.environments.items():
+            self.environmentBox.addItem(env["display"], k)
+
+    @QtCore.pyqtSlot()
+    def on_toggle_extra_options(self):
+        if self.extraOptionsFrame.isVisible():
+            self.extraOptionsFrame.hide()
+        else:
+            self.extraOptionsFrame.show()
+
+    @QtCore.pyqtSlot()
+    def on_fill_extra_options(self):
+        env = self.environmentBox.currentData()
+        self.hostField.setText(self.environments[env]["host"])
+        self.portField.setText(str(self.environments[env]["port"]))
+        self.apiURLField.setText(self.environments[env]["api_url"])
 
     @QtCore.pyqtSlot()
     def on_accepted(self):
         password = self.passwordField.text()
         hashed_password = util.password_hash(password)
         login = self.loginField.text().strip()
+        host = self.hostField.text()
+        port = int(self.portField.text())
+        api_url = self.apiURLField.text()
+
         self.accept()
-        self.finished.emit(login, hashed_password)
+        self.finished.emit(login, hashed_password, host, port, api_url)
 
     @QtCore.pyqtSlot()
     def on_request_quit(self):


### PR DESCRIPTION
This makes it easier for developers/testers to connect to the test system, although this might not be relevant for a whole lot longer.

Adding the LoginWidget as a child of the main window changed it's style so I messed with the client.css a little bit to make the default style a little more generic/consistent.

The advanced options are only shown when you toggle them with the "Advanced" button.

![Screenshot_20190627_135952](https://user-images.githubusercontent.com/17941539/60264709-65813a00-98d3-11e9-8541-ce845ce24367.png)
