### PR TITLE
Ignore extra keyword arguments on game_info message

### DIFF
--- a/src/model/game.py
+++ b/src/model/game.py
@@ -59,7 +59,8 @@ class Game(ModelItem):
                  featured_mod,
                  sim_mods,
                  password_protected,
-                 visibility):
+                 visibility,
+                 **kwargs):
 
         ModelItem.__init__(self)
 


### PR DESCRIPTION
The last server PR added a few more fields to the `game_info` message, but the client encodes exactly the fields that it expects in the constructor of the `Game` object:
```
2020-09-24 16:53:05,524 ERROR    client.connection              Error dispatching JSON: {"command":"game_info","visibility":"public","password_protected":false,"uid":12714595,"title":"1.2K+","state":"open","game_type":"custom","featured_mod":"faf","sim_mods":{},"mapname":"dualgap_adaptive.v0009","map_file_path":"maps/dualgap_adaptive.v0009.zip","host":"RichGuru","num_players":2,"max_players":12,"launched_at":null,"rating_type":"global","rating_min":null,"rating_max":null,"enforce_rating_range":false,"teams":{"2":["RichGuru"],"3":["ddaafucawstmoi"]}}
Traceback (most recent call last):
  File "src\client\connection.py", line 239, in readFromServer
  File "src\client\connection.py", line 325, in dispatch
  File "src\client\connection.py", line 383, in handle_game_info
  File "src\client\connection.py", line 392, in _update_game
TypeError: __init__() got an unexpected keyword argument 'game_type'
```
For forward compatibility, we just ignore any extra fields.
