### PR TITLE
Fix release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pytest
 pytest-cov
 pytest-mock
 pytest-qt==3.3.0
-semantic_version
+semantic_version==2.8.5
 idna
 jsonschema==2.6.0
 jinja2

--- a/src/vaults/dialogs.py
+++ b/src/vaults/dialogs.py
@@ -43,7 +43,7 @@ class VaultDownloadDialog(object):
         self._progress.canceled.connect(self._dler.cancel)
 
         progressBar = QtWidgets.QProgressBar(self._progress)
-        progressBar.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        progressBar.setAlignment(QtCore.Qt.AlignCenter)
         self._progress.setBar(progressBar)
 
         self.timer = QtCore.QTimer()


### PR DESCRIPTION
`cx_Freeze==5.0.2` apparently is not compatible with the new version of `semantic_version` (5.9.0), so use older one
also, fix Qt namespace, so it's compatible with PyQt 5.7.1