### PR TITLE
Workaround `Premature EOF` error in live replays (and some other fixes)

### DIFF
--- a/res/client/client.css
+++ b/res/client/client.css
@@ -381,6 +381,11 @@ QLineEdit:disabled {
     border-bottom-right-radius: 5px;
 }
 
+QLineEdit#mapName, QLineEdit#playerName
+{
+    background-color: #353535;
+}
+
 QFrame#rankedFrame
 {
     border-style:solid;

--- a/res/replays/replays.ui
+++ b/res/replays/replays.ui
@@ -34,58 +34,157 @@
      <number>0</number>
     </property>
     <item row="0" column="0">
-     <widget class="QTreeWidget" name="liveTree">
-      <property name="focusPolicy">
-       <enum>Qt::FocusPolicy::NoFocus</enum>
+     <widget class="QSplitter" name="liveReplaysWidgetSplitter">
+      <property name="orientation">
+       <enum>Qt::Orientation::Horizontal</enum>
       </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
-      </property>
-      <property name="iconSize">
-       <size>
-        <width>32</width>
-        <height>32</height>
-       </size>
-      </property>
-      <property name="verticalScrollMode">
-       <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
-      </property>
-      <property name="rootIsDecorated">
-       <bool>false</bool>
-      </property>
-      <property name="sortingEnabled">
-       <bool>true</bool>
-      </property>
-      <property name="allColumnsShowFocus">
-       <bool>true</bool>
-      </property>
-      <property name="columnCount">
-       <number>3</number>
-      </property>
-      <attribute name="headerVisible">
-       <bool>false</bool>
-      </attribute>
-      <attribute name="headerDefaultSectionSize">
-       <number>39</number>
-      </attribute>
-      <attribute name="headerStretchLastSection">
-       <bool>false</bool>
-      </attribute>
-      <column>
-       <property name="text">
-        <string notr="true">1</string>
+      <widget class="QTreeWidget" name="liveTree">
+       <property name="focusPolicy">
+        <enum>Qt::FocusPolicy::NoFocus</enum>
        </property>
-      </column>
-      <column>
-       <property name="text">
-        <string notr="true">2</string>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SelectionMode::NoSelection</enum>
        </property>
-      </column>
-      <column>
-       <property name="text">
-        <string notr="true">3</string>
+       <property name="iconSize">
+        <size>
+         <width>32</width>
+         <height>32</height>
+        </size>
        </property>
-      </column>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+       </property>
+       <property name="rootIsDecorated">
+        <bool>false</bool>
+       </property>
+       <property name="sortingEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="allColumnsShowFocus">
+        <bool>true</bool>
+       </property>
+       <property name="columnCount">
+        <number>3</number>
+       </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="headerDefaultSectionSize">
+        <number>39</number>
+       </attribute>
+       <attribute name="headerStretchLastSection">
+        <bool>false</bool>
+       </attribute>
+       <column>
+        <property name="text">
+         <string notr="true">1</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string notr="true">2</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string notr="true">3</string>
+        </property>
+       </column>
+      </widget>
+      <widget class="QGroupBox" name="liveTreeFilters">
+       <property name="title">
+        <string>Filters</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignmentFlag::AlignCenter</set>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Game Type:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="gameTypeComboBox">
+          <item>
+           <property name="text">
+            <string>Any</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Max Players:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="maxPlayersComboBox">
+          <item>
+           <property name="text">
+            <string>Any</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Num Players:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="numPlayersComboBox">
+          <item>
+           <property name="text">
+            <string>Any</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>21</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="hideModdedCheckBox">
+          <property name="text">
+           <string>Hide modded</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Featured Mod:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="featuredModComboBox">
+          <item>
+           <property name="text">
+            <string>Any</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
    </layout>
@@ -868,7 +967,7 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <layout class="QGridLayout" name="gridLayout_9" rowstretch="0">
+          <layout class="QGridLayout" name="gridLayout_9" rowstretch="0,0">
            <property name="leftMargin">
             <number>0</number>
            </property>

--- a/src/chat/channel_view.py
+++ b/src/chat/channel_view.py
@@ -351,7 +351,7 @@ class ChatLineFormatter:
             text = self._wrap_me(irc_escape(text), data.meta.my_mention())
 
         sender_name = self._sender_name(data)
-        elided_sender = self._font_metrics.elidedText(sender_name, Qt.TextElideMode.ElideRight, 99)
+        elided_sender = self._font_metrics.elidedText(sender_name, Qt.TextElideMode.ElideRight, 98)
         if mtype in (ChatLineType.MESSAGE, ChatLineType.NOTICE):
             elided_sender += ":"
             text = "&nbsp;" + text

--- a/src/chat/channel_widget.py
+++ b/src/chat/channel_widget.py
@@ -230,17 +230,8 @@ class ChannelWidget(QObject):
     def show_chatter_list(self, should_show):
         self.nick_frame.setVisible(should_show)
 
-    def append_line(self, text):
-        # QTextEdit has its own ideas about scrolling and does not stay
-        # in place when adding content
-        self._sticky_scroll.save_scroll()
-
-        cursor = self.chat_area.textCursor()
-        cursor.movePosition(QTextCursor.MoveOperation.End)
-        self.chat_area.setTextCursor(cursor)
-        self.chat_area.insertHtml(text)
-
-        self._sticky_scroll.restore_scroll()
+    def append_line(self, text: str) -> None:
+        self.chat_area.append(text)
 
     def remove_lines(self, number):
         cursor = self.chat_area.textCursor()

--- a/src/chat/channel_widget.py
+++ b/src/chat/channel_widget.py
@@ -165,6 +165,9 @@ class ChannelWidget(QObject):
         self.chat_area.anchorClicked.connect(self._url_clicked)
         self._override_widget_methods()
         self._load_css()
+        self._sticky_scroll = ChatAreaStickyScroll(
+            self.chat_area.verticalScrollBar(),
+        )
 
     def _override_widget_methods(self):
 
@@ -227,8 +230,17 @@ class ChannelWidget(QObject):
     def show_chatter_list(self, should_show):
         self.nick_frame.setVisible(should_show)
 
-    def append_line(self, text: str) -> None:
-        self.chat_area.append(text)
+    def append_line(self, text):
+        # QTextEdit has its own ideas about scrolling and does not stay
+        # in place when adding content
+        self._sticky_scroll.save_scroll()
+
+        cursor = self.chat_area.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.chat_area.setTextCursor(cursor)
+        self.chat_area.insertHtml(text)
+
+        self._sticky_scroll.restore_scroll()
 
     def remove_lines(self, number):
         cursor = self.chat_area.textCursor()
@@ -326,3 +338,32 @@ class ChannelWidget(QObject):
         current = self.current_search_index + 1
         total = len(self.highlighter.search_results)
         self.search_label.setText(f"{current} out of {total}")
+
+
+class ChatAreaStickyScroll:
+    def __init__(self, scrollbar):
+        self._scrollbar = scrollbar
+        self._scrollbar.valueChanged.connect(self._track_maximum)
+        self._scrollbar.rangeChanged.connect(self._stick_at_range_changed)
+        self._is_set_to_maximum = True
+        self._old_value = self._scrollbar.value()
+        self._saved_scroll = 0
+
+    def save_scroll(self):
+        self._saved_scroll = self._scrollbar.value()
+
+    def restore_scroll(self):
+        if self._is_set_to_maximum:
+            self._scrollbar.setValue(self._scrollbar.maximum())
+        else:
+            self._scrollbar.setValue(self._saved_scroll)
+
+    def _track_maximum(self, val):
+        self._is_set_to_maximum = val == self._scrollbar.maximum()
+        self._old_value = val
+
+    def _stick_at_range_changed(self, min_, max_):
+        if self._is_set_to_maximum:
+            self._scrollbar.setValue(max_)
+        else:
+            self._scrollbar.setValue(self._old_value)

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -55,6 +55,7 @@ from src.fa.game_session import GameSession
 from src.fa.maps import CachedMapsMetadata
 from src.fa.maps import getUserMapsFolder
 from src.fa.replay import WatchedReplaysTracker
+from src.fa.replaylivestreamer import LiveReplayStreamer
 from src.games import GamesWidget
 from src.games.gameitem import GameViewBuilder
 from src.games.gamemodel import GameModel
@@ -449,7 +450,8 @@ class ClientWindow(FormClass, BaseClass):
 
         self._alias_viewer = AliasWindow.build(parent_widget=self)
         self._alias_search_window = AliasSearchWindow(self, self._alias_viewer)
-        self._game_runner = GameRunner(self.gameset, self)
+        self.live_replay_streamer = LiveReplayStreamer()
+        self._game_runner = GameRunner(self.gameset, self.live_replay_streamer, self)
 
         self.connectivity_dialog = None
 

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -2017,7 +2017,6 @@ class ClientWindow(FormClass, BaseClass):
             self.game_session.game_visibility = game.visibility.value
 
     def handle_matchmaker_info(self, message: ServerMessage) -> None:
-        logger.debug("Handling matchmaker info with message %s", message)
         if not self.me.player:
             return
         self.matchmaker_info.emit(message)

--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -956,6 +956,8 @@ class ClientWindow(FormClass, BaseClass):
         progress.setLabelText("Closing ForgedAllianceForever.exe")
         if fa.instance.running():
             fa.instance.close()
+        if fa.replay_instance.running():
+            fa.replay_instance.close()
 
         # Terminate Lobby Server connection
         self.lobby_reconnector.enabled = False

--- a/src/config/production.py
+++ b/src/config/production.py
@@ -53,6 +53,7 @@ default_values = {
     'replay_server/port': 15000,
     'relay_server/host': 'lobby.{host}',
     'relay_server/port': 8000,
+    'replay_stream/pipe_path': r'\\.\pipe\fafreplay',
     'vault/map_preview_url': 'https://content.{host}/maps/previews/{size}/{name}.png',
     'vault/map_download_url': "https://content.{host}/maps/{name}.zip",
     'JAVA_ICE_ADAPTER_RELEASE_URL': 'https://api.github.com/repos/faforever/java-ice-adapter/releases',  # noqa: E501

--- a/src/fa/game_runner.py
+++ b/src/fa/game_runner.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING
 from typing import NamedTuple
 
 from src import fa
-from src.fa.replay import replay
+from src.config import Settings
+from src.fa.replaylivestreamer import LiveReplayStreamer
 from src.model.game import Game
 from src.model.game import GameState
 from src.model.gameset import Gameset
@@ -21,10 +22,16 @@ class GameLaunchArguments(NamedTuple):
 
 
 class GameRunner:
-    def __init__(self, gameset: Gameset, client_window: ClientWindow) -> None:
+    def __init__(
+        self,
+        gameset: Gameset,
+        replay_streamer: LiveReplayStreamer,
+        client_window: ClientWindow,
+    ) -> None:
         self._gameset = gameset
         self._client_window = client_window     # FIXME
         self._launch_args: GameLaunchArguments | None = None
+        self._live_replay_streamer = replay_streamer
 
     def set_launch_args(self, args: GameLaunchArguments) -> None:
         self._launch_args = args
@@ -62,7 +69,10 @@ class GameRunner:
         if game.state == GameState.OPEN:
             self._join_game_from_url(gurl)
         elif game.state == GameState.PLAYING:
-            replay(gurl)
+            if not game.has_live_replay and Settings.get("game/pipe_live_replay", True, type=bool):
+                game.warn_live_delay(self._client_window)
+            else:
+                self._live_replay_streamer.start_live_replay(gurl)
 
     def _join_game_from_url(self, gurl: GameUrl) -> None:
         logger.debug("Joining game from URL: " + gurl.to_url().toString())

--- a/src/fa/replay.py
+++ b/src/fa/replay.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import sys
 
 from compression import zstd
 from PyQt6.QtCore import QByteArray
@@ -145,11 +146,15 @@ def replay(source, detach=False):
             mapname = source.map
             replay_id = source.uid
             sim_mods = source.mods
-            # whip the URL into shape so ForgedAllianceForever.exe
-            # understands it
+            # whip the URL into shape so ForgedAllianceForever.exe understands it
             url.setScheme("gpgnet")
             url.setQuery(QUrlQuery(""))
-            arg_string = url.toString()
+
+            # TODO: handle linux too
+            if sys.platform == "win32" and Settings.get("game/pipe_live_replay", True, type=bool):
+                arg_string = Settings.get("replay_stream/pipe_path", "")
+            else:
+                arg_string = url.toString()
         else:
             QMessageBox.critical(
                 None,

--- a/src/fa/replaylivestreamer.py
+++ b/src/fa/replaylivestreamer.py
@@ -1,0 +1,200 @@
+import logging
+import sys
+from queue import Queue
+from threading import Thread
+from typing import Any
+from typing import ClassVar
+from typing import cast
+
+from PyQt6.QtCore import QByteArray
+from PyQt6.QtCore import QObject
+from PyQt6.QtCore import QUrl
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtNetwork import QAbstractSocket
+from PyQt6.QtWebSockets import QWebSocket
+from PyQt6.QtWidgets import QMessageBox
+
+from src.api.ApiAccessors import UserApiAccessor
+from src.config import Settings
+from src.decorators import with_logger
+from src.fa.replay import replay
+from src.util.gameurl import GameUrl
+
+if sys.platform == "win32":
+    import win32file
+    import win32pipe
+    import win32security
+
+
+@with_logger
+class StreamWriter(QObject):
+    _logger: ClassVar[logging.Logger]
+
+    ready = pyqtSignal()
+    not_ready = pyqtSignal()
+    closed = pyqtSignal()
+
+    _close = pyqtSignal()
+    _abort = pyqtSignal()
+
+    def __init__(self, gurl: GameUrl) -> None:
+        super().__init__()
+        self.game_url = gurl
+
+        self.socket = QWebSocket()
+        self.socket.binaryMessageReceived.connect(self.on_server_message)
+        self.socket.connected.connect(self.on_socket_connected)
+        self.socket.disconnected.connect(self.on_socket_disconnected)
+
+        self.pipe_connected: int | None = None
+
+        self.queue: Queue[bytes] = Queue()
+        self._thread = Thread(target=self.stream, daemon=True)
+
+        # we can't simply call methods from different threads
+        # with Qt, but we are safe to connect signals
+        self._abort.connect(self.abort)
+        self._close.connect(self.close)
+
+        self._ready = False
+        self._finished = True
+
+        # Game process doesn't want to end replay like it does with TCP socket
+        # or regular .scfareplay file -- it just hangs
+        #
+        # Sending 2048+ bytes of invalid replay data deals with hanging, but
+        # in-game replay still won't end "properly" -- the simulation will
+        # just stop and spectator won't be able to click around -- only to exit
+        #
+        # Maybe there is a way to force a "proper" ending, but for now we'll
+        # just prevent hanging
+        self._terminator = b"\x00" * 2048
+
+    def start(self) -> None:
+        self._finished = False
+        self._logger.debug("Starting named pipe thread...")
+        self._thread.start()
+
+    def stream(self) -> None:
+        pipe = win32pipe.CreateNamedPipe(
+            Settings.get("replay_stream/pipe_path", ""),
+            win32pipe.PIPE_ACCESS_OUTBOUND,
+            win32pipe.PIPE_TYPE_BYTE | win32pipe.PIPE_WAIT,
+            1, 65536, 65536, 0, win32security.SECURITY_ATTRIBUTES(),
+        )
+        self.pipe_connected = cast(int, win32pipe.ConnectNamedPipe(pipe, None))
+
+        if self.pipe_connected != 0:
+            self._logger.warning(
+                "Coul not connect named pipe. ConnectNamedPipe returned %s",
+                self.pipe_connected,
+            )
+            win32file.CloseHandle(pipe)
+            self._close.emit()
+            return
+
+        while True:
+            data = self.queue.get()
+            try:
+                win32file.WriteFile(pipe, data)
+                if data == self._terminator:
+                    self._logger.debug("Ending live replay normaly...")
+                    self._close.emit()
+                    break
+            except Exception as e:
+                self._logger.debug("Ending live replay abrubtly: %s", e)
+                self._abort.emit()
+                break
+            else:
+                self.queue.task_done()
+        win32file.CloseHandle(pipe)
+
+    def connect_to_replay_server(self, url: QUrl) -> None:
+        self.socket.open(url)
+
+    def on_socket_connected(self) -> None:
+        # instead of player login/id there can be anything -- this was used
+        # in the past presumably to identify from who we want to receive replay data.
+        # nowadays replay server merges data from all players, but the format remained
+        # the same, because the game uses this format
+        msg = f"G/{self.game_url.uid}/{self.game_url.player}.scfareplay\x00".encode()
+        self.socket.sendBinaryMessage(msg)
+
+    def on_socket_disconnected(self) -> None:
+        self._logger.info("Replay server disconnected")
+        if not self._finished:
+            self.queue.put(self._terminator)
+        elif self.socket.error() == QAbstractSocket.SocketError.UnknownSocketError:
+            self.not_ready.emit()
+
+    def on_server_message(self, message: QByteArray) -> None:
+        self.queue.put(message.data())
+        if not self._ready:
+            self.ready.emit()
+            self._ready = True
+
+    def abort(self) -> None:
+        self.socket.abort()
+        self.shutdown()
+
+    def close(self) -> None:
+        self.socket.close()
+        self.shutdown()
+
+    def shutdown(self) -> None:
+        self.queue.shutdown()
+        self.pipe_connected = None
+
+        self._finished = True
+
+        self.closed.emit()
+        self._logger.debug("Stream writer closed")
+
+
+@with_logger
+class LiveReplayStreamer(QObject):
+    _logger: ClassVar[logging.Logger]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.api = UserApiAccessor()
+
+        self.game_url: GameUrl | None = None
+        self.writer: StreamWriter | None = None
+
+    def start_live_replay(self, gurl: GameUrl) -> None:
+        # TODO: handle linux too
+        if sys.platform == "win32" and Settings.get("game/pipe_live_replay", True, type=bool):
+            self.game_url = gurl
+            self.api.get("/replay/access", self.on_replay_access_url)
+        else:
+            replay(gurl)
+
+    def on_replay_access_url(self, data: dict[str, Any]) -> None:
+        if self.writer is not None:
+            self._logger.warning("Another instance of StreamWriter is not finished yet.")
+            QMessageBox.warning(None, "Live Replay", "Another live replay is already running.")
+            return
+
+        assert self.game_url is not None
+        self.writer = StreamWriter(self.game_url)
+        self.writer.ready.connect(self.on_writer_ready)
+        self.writer.not_ready.connect(self.on_writer_not_ready)
+        self.writer.closed.connect(self.on_writer_closed)
+        self.writer.connect_to_replay_server(QUrl(data["accessUrl"]))
+
+    def on_writer_ready(self) -> None:
+        assert self.game_url is not None
+        assert self.writer is not None
+        if replay(self.game_url):
+            self.writer.start()
+        else:
+            self.on_writer_closed()
+
+    def on_writer_not_ready(self) -> None:
+        msg = "Could not start live replay.\nReplay server disconnected for no reason"
+        QMessageBox.warning(None, "Error", msg)
+        self.on_writer_closed()
+
+    def on_writer_closed(self) -> None:
+        self.writer = None

--- a/src/fa/replaylivestreamer.py
+++ b/src/fa/replaylivestreamer.py
@@ -70,6 +70,8 @@ class StreamWriter(QObject):
         # just prevent hanging
         self._terminator = b"\x00" * 2048
 
+        self._close_intended = False
+
     def start(self) -> None:
         self._finished = False
         self._logger.debug("Starting named pipe thread...")
@@ -124,7 +126,10 @@ class StreamWriter(QObject):
         self._logger.info("Replay server disconnected")
         if not self._finished:
             self.queue.put(self._terminator)
-        elif self.socket.error() == QAbstractSocket.SocketError.UnknownSocketError:
+        elif (
+            not self._close_intended
+            and self.socket.error() == QAbstractSocket.SocketError.UnknownSocketError
+        ):
             self.not_ready.emit()
 
     def on_server_message(self, message: QByteArray) -> None:
@@ -134,10 +139,12 @@ class StreamWriter(QObject):
             self._ready = True
 
     def abort(self) -> None:
+        self._close_intended = True
         self.socket.abort()
         self.shutdown()
 
     def close(self) -> None:
+        self._close_intended = True
         self.socket.close()
         self.shutdown()
 
@@ -189,7 +196,7 @@ class LiveReplayStreamer(QObject):
         if replay(self.game_url):
             self.writer.start()
         else:
-            self.on_writer_closed()
+            self.writer.abort()
 
     def on_writer_not_ready(self) -> None:
         msg = "Could not start live replay.\nReplay server disconnected for no reason"

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -300,9 +300,6 @@ class GamesWidget(FormClass, BaseClass):
         """
         Hosting a game event
         """
-        if not fa.instance.available():
-            return
-
         if (
             self.party is not None
             and self.party.member_count > 1

--- a/src/games/_gameswidget.py
+++ b/src/games/_gameswidget.py
@@ -236,16 +236,24 @@ class GamesWidget(FormClass, BaseClass):
                 for i in range(0, self.modList.count()):
                     if self.modList.item(i) == old_mod:
                         self.modList.takeItem(i)
+
+                # FIXME: gameswidget shouldn't handle replayswidget
                 for i in range(self.client.replays.modList.count()):
                     if self.client.replays.modList.itemText(i) == old_mod.mod:
                         self.client.replays.modList.removeItem(i)
+                for i in range(self.client.replays.featuredModComboBox.count()):
+                    if self.client.replays.featuredModComboBox.itemText(i) == old_mod.mod:
+                        self.client.replays.featuredModComboBox.removeItem(i)
 
             if featured_mod.visible:
                 self.modList.addItem(self.mods[mod])
             else:
                 mod_invisible[mod] = self.mods[mod]
 
+            # FIXME: gameswidget shouldn't handle replayswidget
             self.client.replays.modList.addItem(mod)
+            if featured_mod.visible:
+                self.client.replays.featuredModComboBox.addItem(mod)
 
     def stopSearch(self):
         self.searching = {"ladder1v1": False}

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -471,6 +471,9 @@ class HostGameWidget(QDialog):
         self.update_map_preview(item)
 
     def hosting(self) -> None:
+        if not fa.instance.available():
+            return
+
         password = None
         if self.game.password_protected:
             password = self.ui.passEdit.text()

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -190,6 +190,12 @@ class HostGameWidget(QDialog):
         self.ui.mapPlayersMaximum.valueChanged.connect(self.on_map_max_p_changed)
 
         self.ui.modTypeRadioGroup.buttonToggled.connect(self.on_mod_display_type_changed)
+        mod_type = Settings.get("fa.games/displayed_mods", "All")
+        for button in self.ui.modTypeRadioGroup.buttons():
+            if mod_type == button.text():
+                button.setChecked(True)
+                break
+
         self.ui.mapNameFilter.textChanged.connect(self.filter_maps_by_name)
         self.ui.modNameFilter.textChanged.connect(self.filter_mods_by_name)
 
@@ -221,7 +227,7 @@ class HostGameWidget(QDialog):
         self.ui.mapPlayersMinimum.setValue(0)
         self.ui.mapPlayersMaximum.setValue(16)
 
-    def on_mod_display_type_changed(self, _: QAbstractButton, checked: bool) -> None:
+    def on_mod_display_type_changed(self, button: QAbstractButton, checked: bool) -> None:
         if not checked:
             return
         for i in range(self.ui.modList.count()):
@@ -234,6 +240,7 @@ class HostGameWidget(QDialog):
                 item.setHidden(not mod.ui_only)
             elif self.ui.modSimRadio.isChecked():
                 item.setHidden(mod.ui_only)
+        Settings.set("fa.games/displayed_mods", button.text())
 
     def on_map_min_w_changed(self, v: int) -> None:
         v = min(v, self.ui.mapWidthMaximum.value())

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -8,6 +8,8 @@ from typing import Self
 
 from PyQt6.QtCore import QTimer
 from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QMessageBox
+from PyQt6.QtWidgets import QWidget
 
 from src.decorators import with_logger
 from src.model.modelitem import ModelItem
@@ -300,6 +302,19 @@ class Game(ModelItem):
         pretty = pretty.replace("_", " ")
         pretty = string.capwords(pretty)
         return pretty
+
+    def warn_live_delay(self, parent: QWidget | None = None) -> None:
+        assert self.launched_at is not None
+        delta = time.gmtime(self.LIVE_REPLAY_DELAY_SECS - (time.time() - self.launched_at))
+        wait_str = time.strftime('%M Min %S Sec', delta)
+        QMessageBox.information(
+            parent,
+            "5 Minute Live Game Delay",
+            (
+                "It is too early to join the Game.\n"
+                f"You have to wait {wait_str} to join."
+            ),
+        )
 
 
 def message_to_game_args(m: ServerMessage) -> bool:

--- a/src/model/game.py
+++ b/src/model/game.py
@@ -37,9 +37,9 @@ class GameVisibility(Enum):
 
 
 class GameType(Enum):
-    COOP = "coop"
     CUSTOM = "custom"
     MATCHMAKER = "matchmaker"
+    COOP = "coop"
 
 
 @with_logger

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -279,8 +279,9 @@ class LiveReplaysWidgetHandler:
 
         if self.liveTree.indexOfTopLevelItem(item) == -1:
             # Notify other modules that we're watching a replay
-            self.client.viewing_replay.emit(item.gurl)
-            replay(item.gurl)
+            if not Settings.get("game/replay_process", True, type=bool):
+                self.client.viewing_replay.emit(item.gurl)
+            self.client.live_replay_streamer.start_live_replay(item.gurl)
 
     def _addExistingGames(self, gameset):
         for game in gameset.values():
@@ -1107,32 +1108,19 @@ class ReplayVaultWidgetHandler:
                             self._startReplay(name)
                             break
                 else:
-                    delta = time.gmtime(
-                        game.LIVE_REPLAY_DELAY_SECS
-                        - (time.time() - game.launched_at),
-                    )
-                    wait_str = time.strftime('%M Min %S Sec', delta)
-                    QtWidgets.QMessageBox.information(
-                        client.instance,
-                        "5 Minute Live Game Delay",
-                        (
-                            "It is too early to join the Game.\n"
-                            "You have to wait {} to join.".format(wait_str)
-                        ),
-                    )
-            elif item.replay["endTime"] is None and not item.live_delay:
+                    game.warn_live_delay(client.instance)
+            elif item.replay["endTime"] is None:
                 # player probably foed us; hiding started games from foes
                 # makes no sense, but currently server does that
                 name = item.replay["host"]["login"]
-                if (player := self._playerset.get_by_name(name)) is not None:  # still logged in
-                    url = GameUrl(
-                        GameUrlType.LIVE_REPLAY,
-                        item.mapname,
-                        item.mod,
-                        item.uid,
-                        player.id,
-                    )
-                    replay(url)
+                url = GameUrl(
+                    GameUrlType.LIVE_REPLAY,
+                    item.mapname,
+                    item.mod,
+                    item.uid,
+                    name,
+                )
+                self.client.live_replay_streamer.start_live_replay(url)
             else:  # game ended - ask to start replay
                 if QtWidgets.QMessageBox.question(
                     client.instance,
@@ -1150,11 +1138,15 @@ class ReplayVaultWidgetHandler:
                 self.replayDownload.get(req)
 
     def _startReplay(self, name: str | None) -> None:
-        if name is None or (player := self._playerset.get_by_name(name)) is None:
+        if (
+            name is None
+            or (player := self._playerset.get_by_name(name)) is None
+            or player.currentGame is None
+        ):
             return
-        if not player.currentGame:
-            return
-        replay(player.currentGame.url(player.id))
+
+        url = player.currentGame.url(player.id)
+        self.client.live_replay_streamer.start_live_replay(url)
 
     def matchUsernameCheckboxChange(self, state):
         self.match_username = state

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -32,6 +32,7 @@ from src.fa.replay import WatchedReplaysTracker
 from src.fa.replay import replay
 from src.model.game import Game
 from src.model.game import GameState
+from src.model.game import GameType
 from src.model.gameset import Gameset
 from src.model.playerset import Playerset
 from src.qt.utils import qpainter
@@ -70,6 +71,11 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
         self._game.updated.connect(self._update_game)
         self._set_show_delay()
         self._update_game(self._game)
+        self._filtered_out = False
+
+    def set_filtered_out(self, filtered: bool, /) -> None:
+        self._filtered_out = filtered
+        self.setHidden(filtered)
 
     def _set_show_delay(self):
         if time.time() - self.launch_time < self.LIVEREPLAY_DELAY:
@@ -80,7 +86,7 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
             QtCore.QTimer.singleShot(int(1000 * delay_time), self._show_item)
 
     def _show_item(self):
-        self.setHidden(False)
+        self.setHidden(self._filtered_out)
 
     def _map_preview_downloaded(self, preview_file: str, pixmap: QtGui.QPixmap) -> None:
         if util.pretty_decoded_basename(preview_file) != self._game.mapname:
@@ -206,7 +212,7 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
 
 
 class LiveReplaysWidgetHandler:
-    def __init__(self, liveTree, client, gameset):
+    def __init__(self, liveTree, client, gameset, live_tree_filters, splitter):
         self.liveTree = liveTree
         self.liveTree.itemDoubleClicked.connect(self.liveTreeDoubleClicked)
         self.liveTree.itemPressed.connect(self.liveTreePressed)
@@ -219,13 +225,59 @@ class LiveReplaysWidgetHandler:
         self.liveTree.header().setSectionResizeMode(
             2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents,
         )
+        self.game_type_filter = live_tree_filters[0]
+        self.game_type_filter.addItems(typ.value for typ in GameType)
+        self.game_type_filter.currentIndexChanged.connect(self.filter_games)
+
+        self.max_players_filter = live_tree_filters[1]
+        self.max_players_filter.addItems(map(str, range(1, 17)))
+        self.max_players_filter.currentIndexChanged.connect(self.filter_games)
+
+        self.num_players_filter = live_tree_filters[2]
+        self.num_players_filter.addItems(map(str, range(1, 17)))
+        self.num_players_filter.currentIndexChanged.connect(self.filter_games)
+
+        self.featured_mod_filter = live_tree_filters[3]
+        self.featured_mod_filter.currentIndexChanged.connect(self.filter_games)
+        self.modded_games_filter = live_tree_filters[4]
+        self.modded_games_filter.checkStateChanged.connect(self.filter_games)
 
         self.client = client
         self.gameset = gameset
         self.gameset.newLiveGame.connect(self._newGame)
         self._addExistingGames(gameset)
 
+        self.splitter = splitter
+        splitter_sizes = Settings.get_list("replay/live_splitter", type=int, default=[])
+        if len(splitter) == 2:
+            self.splitter.setSizes(splitter_sizes)
+        self.splitter.splitterMoved.connect(self.on_splitter_moved)
+
         self.games = {}
+
+    def on_splitter_moved(self) -> None:
+        Settings.set("replay/live_splitter", self.splitter.sizes())
+
+    def filter_games(self) -> None:
+        self._filter_games()
+
+    def _filter_games(self, count: int | None = None) -> None:
+        game_type = self.game_type_filter.currentText()
+        max_players = self.max_players_filter.currentText()
+        num_players = self.num_players_filter.currentText()
+        mod = self.featured_mod_filter.currentText()
+        hide_modded = self.modded_games_filter.checkState() == QtCore.Qt.CheckState.Checked
+
+        for i in range(count or self.liveTree.topLevelItemCount()):
+            item = self.liveTree.topLevelItem(i)
+            hide = any((
+                game_type != "Any" and item._game.game_type.value != game_type,
+                max_players != "Any" and item._game.max_players != int(max_players),
+                num_players != "Any" and item._game.num_players != int(num_players),
+                mod != "Any" and item._game.featured_mod != mod,
+                hide_modded and item._game.sim_mods,
+            ))
+            item.set_filtered_out(hide)
 
     def liveTreePressed(self, item):
         if QtWidgets.QApplication.mouseButtons() != QtCore.Qt.MouseButton.RightButton:
@@ -293,6 +345,7 @@ class LiveReplaysWidgetHandler:
         self.games[game] = item
         self.liveTree.insertTopLevelItem(0, item)
         game.updated.connect(self._check_game_closed)
+        self._filter_games(1)
 
     def _check_game_closed(self, game):
         if game.state == GameState.CLOSED:
@@ -1271,7 +1324,20 @@ class ReplaysWidget(BaseClass, FormClass):
         BaseClass.__init__(self)
         self.setupUi(self)
 
-        self.liveManager = LiveReplaysWidgetHandler(self.liveTree, client, gameset)
+        live_filters = [
+            self.gameTypeComboBox,
+            self.maxPlayersComboBox,
+            self.numPlayersComboBox,
+            self.featuredModComboBox,
+            self.hideModdedCheckBox,
+        ]
+        self.liveManager = LiveReplaysWidgetHandler(
+            self.liveTree,
+            client,
+            gameset,
+            live_filters,
+            self.liveReplaysWidgetSplitter,
+        )
         self.localManager = LocalReplaysWidgetHandler(self.myTree, client)
         self.vaultManager = ReplayVaultWidgetHandler(self, dispatcher, client, gameset, playerset)
         self.currentChanged.connect(self.on_tab_changed)

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -75,7 +75,7 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
 
     def set_filtered_out(self, filtered: bool, /) -> None:
         self._filtered_out = filtered
-        self.setHidden(filtered)
+        self.setHidden(filtered or self._delayed)
 
     def _set_show_delay(self):
         if time.time() - self.launch_time < self.LIVEREPLAY_DELAY:
@@ -84,8 +84,12 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
             elapsed_time = time.time() - self.launch_time
             delay_time = self.LIVEREPLAY_DELAY - elapsed_time
             QtCore.QTimer.singleShot(int(1000 * delay_time), self._show_item)
+            self._delayed = True
+        else:
+            self._delayed = False
 
     def _show_item(self):
+        self._delayed = False
         self.setHidden(self._filtered_out)
 
     def _map_preview_downloaded(self, preview_file: str, pixmap: QtGui.QPixmap) -> None:

--- a/src/util/settings_menus.py
+++ b/src/util/settings_menus.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 import os
+import sys
 import textwrap
 from typing import TYPE_CHECKING
 
@@ -303,9 +302,19 @@ class GameSettingsUI:
         self.runReplaysSeparatelyCheckBox.setToolTip(tooltip)
         self.forceAffinityCheckBox = QCheckBox("Force Affinity")
         self.forceAffinityCheckBox.setToolTip("Allow the game to adjust process affinity")
+        self.liveReplaysWorkaround = QCheckBox("Enable Live Replay Workaround")
+        if sys.platform == "win32":
+            self.liveReplaysWorkaround.setToolTip(
+                "Use pipe to stream live replay data. Avoids Premature EOF errors,\n"
+                "but the replay will end abruptly with no ability to select armies/see\n"
+                "statistics/etc.",
+            )
+        else:
+            self.liveReplaysWorkaround.setToolTip("[Windows only setting]")
         misc_settings_layout.addWidget(self.gameLogsCheckBox)
         misc_settings_layout.addWidget(self.runReplaysSeparatelyCheckBox)
         misc_settings_layout.addWidget(self.forceAffinityCheckBox)
+        misc_settings_layout.addWidget(self.liveReplaysWorkaround)
 
         self.buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
@@ -338,6 +347,13 @@ class GameSettings(QDialog):
         self.ui.forceAffinityCheckBox.setChecked(
             Settings.get("game/force_affinity", True, type=bool),
         )
+        if sys.platform == "win32":
+            self.ui.liveReplaysWorkaround.setChecked(
+                Settings.get("game/pipe_live_replay", True, type=bool),
+            )
+        else:
+            self.ui.liveReplaysWorkaround.setEnabled(False)
+
         self.ui.browseGameButton.clicked.connect(
             lambda: self.browse_directory(self.ui.gamePathInput),
         )
@@ -383,6 +399,7 @@ class GameSettings(QDialog):
         Settings.set("game/logs", self.ui.gameLogsCheckBox.isChecked())
         Settings.set("game/replay_process", self.ui.runReplaysSeparatelyCheckBox.isChecked())
         Settings.set("game/force_affinity", self.ui.forceAffinityCheckBox.isChecked())
+        Settings.set("game/pipe_live_replay", self.ui.liveReplaysWorkaround.isChecked())
         if vault_path != util.VAULTS_BASE_DIR:
             # TODO: change without restart (or make sure that restart is not needed)
             util.change_vaults_base_dir(vault_path)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows live replay streaming with an opt-in workaround
  * Replays filters panel (game type, player counts, featured mods) and split-pane layout
  * Per-item live-replay filtering and persisted splitter sizes

* **Improvements**
  * Live replay start now routes through the new streamer with user-facing delay warnings

* **Style**
  * Darker background for name input fields

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->