### PR TITLE
Fix showing live replays prematurely and maps display in host game widget

### DIFF
--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -487,7 +487,7 @@ class HostGameWidget(QDialog):
 
         allmaps = maps.CachedMapsMetadata.get_installed_maps()
         for name in reversed(mapnames):
-            item = QListWidgetItem(name)
+            item = QListWidgetItem(maps.getDisplayName(name))
             item.setData(QtCore.Qt.ItemDataRole.UserRole, allmaps[name])
             item.setForeground(self._unseen_mapgen_brush)
             self.ui.mapList.addItem(item)

--- a/src/games/hostgamewidget.py
+++ b/src/games/hostgamewidget.py
@@ -480,6 +480,8 @@ class HostGameWidget(QDialog):
         if not mapnames:
             return
 
+        self.ui.showFavouritesOnlyCheck.setChecked(False)
+
         if len(mapnames) > 1:
             UnseenMapgenNames.update(set(mapnames))
 

--- a/src/replays/_replayswidget.py
+++ b/src/replays/_replayswidget.py
@@ -83,7 +83,6 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
         self._map_dl_request.done.connect(self._map_preview_downloaded)
 
         self._game.updated.connect(self._update_game)
-        self._set_show_delay()
         self._update_game(self._game)
         self._filtered_out = False
 
@@ -91,7 +90,7 @@ class LiveReplayItem(QtWidgets.QTreeWidgetItem):
         self._filtered_out = filtered
         self.setHidden(filtered or self._delayed)
 
-    def _set_show_delay(self):
+    def set_show_delay(self) -> None:
         if time.time() - self.launch_time < self.LIVEREPLAY_DELAY:
             self.setHidden(True)
             # Wait until the replayserver makes the replay available
@@ -387,6 +386,7 @@ class LiveReplaysWidgetHandler:
         item = LiveReplayItem(game)
         self.games[game] = item
         self.liveTree.insertTopLevelItem(0, item)
+        item.set_show_delay()
         game.updated.connect(self._check_game_closed)
         self._filter_games(1)
 


### PR DESCRIPTION
* Hide live replay items only after adding them to view
* Format names of newly generated maps with `getDisplayName` function
* Uncheck favourite maps filter button on generating new maps for hosting -- new maps are not favourite yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Maps now display with user-friendly names instead of folder identifiers
  * Favorites-only filter properly resets when viewing maps

* **Improvements**
  * Enhanced live replay display timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->