### PR TITLE
Fix stale OAuth sessions

### DIFF
--- a/src/client/_clientwindow.py
+++ b/src/client/_clientwindow.py
@@ -1210,7 +1210,9 @@ class ClientWindow(FormClass, BaseClass):
             self.show_login_widget()
 
     def on_login_attempt_failed(self) -> None:
+        self.disconnect_()
         self.state = ClientState.DISCONNECTED
+        self._auto_relogin = False
         self.show_login_widget()
 
     def get_creds_and_login(self) -> None:

--- a/src/oauth/oauth_flow.py
+++ b/src/oauth/oauth_flow.py
@@ -99,6 +99,7 @@ class OAuth2Flow(QOAuth2AuthorizationCodeFlow):
 
     def on_request_failed(self, error: QOAuth2AuthorizationCodeFlow.Error) -> None:
         self._logger.error("Request failed with an error: %s", error)
+        self.setToken("")
         self.stop_checking_expiration()
 
     def setup_credentials(self) -> None:

--- a/tests/unit_tests/client/test_authentication.py
+++ b/tests/unit_tests/client/test_authentication.py
@@ -1,0 +1,28 @@
+from unittest.mock import call
+
+
+def test_login_failure_allows_fresh_connection(application, client_instance, mocker):
+    from src.client.clientstate import ClientState
+    from src.util.gameurl import GameUrl
+
+    disconnect = mocker.patch.object(client_instance, "disconnect_")
+    show_login_widget = mocker.patch.object(client_instance, "show_login_widget")
+    mocker.patch.object(client_instance, "_state", ClientState.LOGGED_IN)
+    mocker.patch.object(client_instance, "_auto_relogin", True)
+    lifecycle = mocker.Mock()
+    lifecycle.attach_mock(disconnect, "disconnect")
+    lifecycle.attach_mock(show_login_widget, "show_login_widget")
+
+    client_instance.on_login_attempt_failed()
+
+    assert client_instance.state == ClientState.DISCONNECTED
+    assert not client_instance._auto_relogin
+    assert lifecycle.mock_calls == [call.disconnect(), call.show_login_widget()]
+
+    mocker.patch.object(client_instance.replayServer, "doListen", return_value=True)
+    mocker.patch.object(client_instance.replayServer, "serverPort", return_value=12345)
+    connect = mocker.patch.object(client_instance.lobby_connection, "do_connect")
+    mocker.patch.object(GameUrl, "PORT", -1)
+
+    assert client_instance.do_connect()
+    connect.assert_called_once_with()

--- a/tests/unit_tests/oauth/test_oauth_flow.py
+++ b/tests/unit_tests/oauth/test_oauth_flow.py
@@ -1,0 +1,11 @@
+def test_request_failure_discards_access_token(application):
+    from PyQt6.QtNetworkAuth import QAbstractOAuth
+
+    from src.oauth.oauth_flow import OAuth2Flow
+
+    flow = OAuth2Flow()
+    flow.setToken("expired-token")
+
+    flow.requestFailed.emit(QAbstractOAuth.Error.NetworkError)
+
+    assert flow.token() == ""


### PR DESCRIPTION
Fixes #1163

## Summary

- Discard the in-memory access token when an OAuth request fails.
- Run the existing disconnect cleanup before disabling automatic relogin and prompting for a fresh login.
- Preserve the immediate `DISCONNECTED` state transition so a fresh token can reconnect while the socket closes asynchronously.
- Cover token invalidation and the disconnect/reconnect lifecycle with regression tests.

## Scope

This fixes the deterministic client path that can retain an expired credential. It does not assume that every old-token event observed server-side originates from this path.

## Testing

- `python runtests.py -vv --full-trace` on Windows with Python 3.14.7: 119 passed, 1 skipped
- `pre-commit run --files src/client/_clientwindow.py src/oauth/oauth_flow.py tests/unit_tests/client/test_authentication.py tests/unit_tests/oauth/test_oauth_flow.py`: all configured hooks passed

Please check these boxes as you make your PR ready for merging:

Initial PR:

- [x] PR branch is named `issuenum`-`fix`/`feature`/`cleanup`-`description`
- [x] Code is split into logical commits
- [x] Code has tests
- [x] Final commit includes "Fixes #issue" in commit message

When all builds pass and a maintainer is happy with the PR, the "ready" label will be applied. Please complete these tasks then:

- [ ] Rebase onto develop
- [ ] Add changelog entry
- [ ] Remove this entire template section